### PR TITLE
fix for an erroneous debug line comment that didn't show up during dev.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+### 1.0.0.31.1
+- Emergency fix for an addon loading bug that stemmed from a debug line comment in _Widget.xml
+
 ### 1.0.0.31
 - Enhancement - Option to hide the mouseover glow [Issue #41](https://github.com/kapresoft/wow-addon-actionbar-plus/issues/41)
 - Bug Fix - Blur out items that do not [Issue #47](https://github.com/kapresoft/wow-addon-actionbar-plus/issues/47)

--- a/Core/AddonLib/Widget/_Widget.xml
+++ b/Core/AddonLib/Widget/_Widget.xml
@@ -9,11 +9,7 @@
     <Script file="WidgetMixin.lua"/>
     <Script file="WidgetLibFactory.lua"/>
 
-    <!--@debug@-->
-    <!--  <Script file="MacroTextureDialog.lua"/>  -->
-    <!--@end-debug@-->
     <Script file="MacroEventsHandler.lua"/>
-
     <Include file="Buttons\_Buttons.xml"/>
 
 </Ui>


### PR DESCRIPTION
## This line caused an issue on release version
> Second Line below: XML Comment within an XML comment

```
<!--@debug@-->
    <!--  <Script file="MacroTextureDialog.lua"/>  -->
    <!--@end-debug@-->
```