### PR TITLE
Fix for #121 - Incorrect background texture for items

### DIFF
--- a/Core/AddonLib/Widget/Buttons/ButtonMixin.lua
+++ b/Core/AddonLib/Widget/Buttons/ButtonMixin.lua
@@ -589,6 +589,7 @@ function L:SetTextureAsEmpty()
     self:SetPushedTexture(nil)
     self:SetHighlightTexture(nil)
     self:SetNormalIconAlphaAsEmpty()
+    self:SetVertexColorNormal()
 end
 
 function L:SetNormalIconAlphaAsEmpty()
@@ -599,6 +600,7 @@ end
 
 ---@param alpha number 0.0 to 1.0
 function L:SetNormalIconAlpha(alpha) self:B():GetNormalTexture():SetAlpha(alpha or 1.0) end
+function L:SetVertexColorNormal() self:B():GetNormalTexture():SetVertexColor(1.0, 1.0, 1.0) end
 
 function L:SetNormalIconAlphaDefault()
     if self:IsEmpty() then

--- a/Core/AddonLib/Widget/Buttons/ItemAttributeSetter.lua
+++ b/Core/AddonLib/Widget/Buttons/ItemAttributeSetter.lua
@@ -35,10 +35,7 @@ function S:SetAttributes(btnUI, btnData)
 
     AssertNotNil(itemData.id, 'btnData[item].itemInfo.id')
 
-    local icon = GC.Textures.TEXTURE_EMPTY
-    if itemData.icon then icon = itemData.icon end
-
-    btnUI.widget:SetIcon(icon)
+    btnUI.widget:SetIcon(itemData.icon)
     btnUI:SetAttribute(WAttr.TYPE, WAttr.ITEM)
     btnUI:SetAttribute(WAttr.ITEM, itemData.name)
 


### PR DESCRIPTION
Fix for #121 - Incorrect background texture for items; Fix item vertex color when in an empty state.