### PR TITLE
Fix for #90 and #162

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,8 @@
 [Release Notes](https://github.com/kapresoft/wow-addon-actionbar-plus/releases/tag/1.0.17) | [Full Changelog](https://github.com/kapresoft/wow-addon-actionbar-plus/compare/1.0.16...1.0.17) | [Release Page](https://github.com/kapresoft/wow-addon-actionbar-plus/releases) | [Older Release List](https://github.com/kapresoft/wow-addon-actionbar-plus/blob/main/doc/CHANGELOG-Previous.md)
 
 - Update stealth state for macros #159
+- Mask texture matches button dimensions (instead of default square) #162
+- Some action button icons are showing a rigid dark background #90
 
 ### ActionbarPlus-1.0.17.zip
 

--- a/Core/AddonLib/Widget/Buttons/ButtonMixin.lua
+++ b/Core/AddonLib/Widget/Buttons/ButtonMixin.lua
@@ -27,10 +27,10 @@ local UNIT = GC.UnitIDAttributes
 
 local emptyTexture = GC.Textures.TEXTURE_EMPTY
 local emptyGridTexture = GC.Textures.TEXTURE_EMPTY_GRID
-local highlightTexture = T.TEXTURE_HIGHLIGHT2
-local pushedTextureMask = T.TEXTURE_HIGHLIGHT2
+local highlightTexture = GC.Textures.TEXTURE_EMPTY_GRID
+local pushedTextureMask = GC.Textures.TEXTURE_EMPTY_GRID
 
-local highlightTextureAlpha = 0.2
+local highlightTextureAlpha = 0.5
 local highlightTextureInUseAlpha = 0.5
 local pushedTextureInUseAlpha = 0.5
 local nonEmptySlotAlpha = 1.0
@@ -250,19 +250,14 @@ function L:InitTextures(icon)
 
     self:SetHighlightDefault(btnUI)
     btnUI:SetPushedTexture(icon)
+
     local tex = btnUI:GetPushedTexture()
     CreateMask(btnUI, tex, pushedTextureMask)
-
     tex:SetAlpha(pushedTextureInUseAlpha)
-    local mask = btnUI:CreateMaskTexture()
-    mask:SetPoint(C.TOPLEFT, tex, C.TOPLEFT, 3, -3)
-    mask:SetPoint(C.BOTTOMRIGHT, tex, C.BOTTOMRIGHT, -3, 3)
-    mask:SetTexture(pushedTextureMask, C.CLAMPTOBLACKADDITIVE, C.CLAMPTOBLACKADDITIVE)
-    tex:AddMaskTexture(mask)
 
     local hTexture = btnUI:GetHighlightTexture()
     if hTexture and not hTexture.mask then
-        hTexture.mask = CreateMask(btnUI, hTexture, GC.Textures.TEXTURE_BUTTON_HILIGHT_SQUARE_BLUE)
+        CreateMask(btnUI, hTexture, highlightTexture)
     end
 end
 
@@ -664,24 +659,19 @@ function L:SetButtonStatePushed() self:B():SetButtonState('PUSHED') end
 
 ---Typically used when casting spells that take longer than GCD
 function L: SetHighlightInUse()
-    --todo next: action_button_mouseover_glow is different from highlight in use
-    --this feature is being masked by action_button_mouseover_glow
-    --need to highlight an action being in-use state regardless
     local btn = self:B()
+    self:SetNormalIconAlpha(highlightTextureInUseAlpha)
     local hltTexture = btn:GetHighlightTexture()
     --highlight texture could be nil if action_button_mouseover_glow is disabled
     if not hltTexture then return end
     hltTexture:SetDrawLayer(C.ARTWORK_DRAW_LAYER)
     hltTexture:SetAlpha(highlightTextureInUseAlpha)
-
-    if hltTexture and not hltTexture.mask then
-        -- so that we can show a indicator that a spell is being casted
-        hltTexture.mask = CreateMask(btn, hltTexture, GC.Textures.TEXTURE_BUTTON_HILIGHT_SQUARE_BLUE)
-    end
+    if hltTexture and not hltTexture.mask then CreateMask(btn, hltTexture, highlightTexture) end
 end
 function L:SetHighlightDefault()
     if self:IsEmpty() then return end
     self:SetHighlightEnabled(self:P():IsActionButtonMouseoverGlowEnabled())
+    self:SetNormalIconAlpha(1.0)
 end
 
 function L:RefreshHighlightEnabled()
@@ -881,14 +871,10 @@ end
 ---@param icon string Blizzard Icon
 function L:SetIcon(icon)
     local btn = self:B()
-    btn:SetNormalTexture(icon)
-    btn:SetPushedTexture(icon)
-
+    self:SetNormalTexture(icon)
+    self:SetPushedTexture(icon)
     local nTexture = btn:GetNormalTexture()
-    if not nTexture.mask then
-        nTexture.mask = CreateMask(btn, nTexture, GC.Textures.TEXTURE_HIGHLIGHT_BUTTON_OUTLINE)
-    end
-
+    if not nTexture.mask then CreateMask(btn, nTexture, emptyTexture) end
 end
 
 ---@param buttonData Profile_Button

--- a/Core/AddonLib/Widget/Buttons/ButtonUI.lua
+++ b/Core/AddonLib/Widget/Buttons/ButtonUI.lua
@@ -127,6 +127,22 @@ local function OnDragStart(btnUI)
     w:Fire('OnDragStart')
 end
 
+---@param btn _Button
+---@param texture _Texture
+---@param texturePath string
+local function CreateMask(btn, texture, texturePath)
+    local mask = btn:CreateMaskTexture()
+    local topx, topy = 1, -1
+    local botx, boty = -1, 1
+    local C = GC.C
+    mask:SetPoint(C.TOPLEFT, texture, C.TOPLEFT, topx, topy)
+    mask:SetPoint(C.BOTTOMRIGHT, texture, C.BOTTOMRIGHT, botx, boty)
+    mask:SetTexture(texturePath, C.CLAMPTOBLACKADDITIVE, C.CLAMPTOBLACKADDITIVE)
+    texture.mask = mask
+    texture:AddMaskTexture(mask)
+    return mask
+end
+
 --- Used with `button:RegisterForDrag('LeftButton')`
 ---@param btnUI ButtonUI
 local function OnReceiveDrag(btnUI)
@@ -142,6 +158,12 @@ local function OnReceiveDrag(btnUI)
 
     ---@type ReceiveDragEventHandler
     O.ReceiveDragEventHandler:Handle(btnUI, cursorUtil)
+
+    --local hTexture = btnUI:GetHighlightTexture()
+    --if hTexture and not hTexture.mask then
+    --    print('creating mask')
+    --    hTexture.mask = CreateMask(btnUI, hTexture, GC.Textures.TEXTURE_EMPTY_GRID)
+    --end
 
     btnUI.widget:Fire('OnReceiveDrag')
 end


### PR DESCRIPTION
- Some action button icons are showing a rigid dark background #90
- Mask texture matches button dimensions (instead of default square) #162
