### PR TITLE
Glow remains on the old button when moving a proc'd spell to a different slot

### DIFF
--- a/Core/Lib/Widget/Buttons/ButtonMixin.lua
+++ b/Core/Lib/Widget/Buttons/ButtonMixin.lua
@@ -303,6 +303,7 @@ local function PropsAndMethods(o)
 
     function o:Reset()
         self:ResetCooldown()
+        self:HideOverlayGlow()
         self:ClearAllText()
     end
 


### PR DESCRIPTION
Resolves #321