### PR TITLE
Several Fixes

### DIFF
--- a/ActionbarPlus.toc
+++ b/ActionbarPlus.toc
@@ -1,4 +1,4 @@
-## Interface: 100205
+## Interface: 100206
 ## Version: @project-version@
 ## Title: Actionbar|cff1784d1Plus|r Retail
 ## Notes: Actionbar Addon for World of Warcraft

--- a/Core/ActionbarPlus.lua
+++ b/Core/ActionbarPlus.lua
@@ -51,9 +51,6 @@ local function OnPlayerEnteringWorld(frame, event, ...)
     --@end-debug@
 
     if not isLogin then return end
-    local versionText = GC:GetAddonInfo()
-    local C = GC:GetAceLocale()
-    --pd:vv(function() return C['Addon Initialized Text Format'], versionText, GCC.ABP_COMMAND end)
     pd:vv(GC:GetMessageLoadedText())
 end
 
@@ -261,5 +258,4 @@ local function NewInstance()
 
     return A
 end
-
-ABP = NewInstance()
+if ABP then return end; ABP = NewInstance()

--- a/Core/Global/GlobalConstants.lua
+++ b/Core/Global/GlobalConstants.lua
@@ -241,7 +241,10 @@ local function GlobalConstantProperties(o)
         COMBAT_LOG_EVENT_UNFILTERED = 'COMBAT_LOG_EVENT_UNFILTERED',
         COMPANION_UPDATE = 'COMPANION_UPDATE',
         CVAR_UPDATE = 'CVAR_UPDATE',
+        --- This event fires whenever there's a change to the player's equipment sets. This includes creating, modifying, or deleting an equipment set.
         EQUIPMENT_SETS_CHANGED = 'EQUIPMENT_SETS_CHANGED',
+        --- Triggered after an equipment set swap has been completed. This event helps addons and scripts determine when the gear change process has ended, allowing them to update or react accordingly.
+        --- Event Parameters: result, setID
         EQUIPMENT_SWAP_FINISHED = 'EQUIPMENT_SWAP_FINISHED',
         MODIFIER_STATE_CHANGED = 'MODIFIER_STATE_CHANGED',
 
@@ -252,6 +255,7 @@ local function GlobalConstantProperties(o)
         PLAYER_CONTROL_LOST = 'PLAYER_CONTROL_LOST',
         PLAYER_MOUNT_DISPLAY_CHANGED = 'PLAYER_MOUNT_DISPLAY_CHANGED',
         PLAYER_ENTERING_WORLD = 'PLAYER_ENTERING_WORLD',
+        --- This event fires when the player's currently equipped items change. It provides specifics about which slot had an item change, making it useful for tracking equipped items in real-time.
         PLAYER_REGEN_DISABLED = 'PLAYER_REGEN_DISABLED',
         PLAYER_REGEN_ENABLED = 'PLAYER_REGEN_ENABLED',
         PLAYER_STARTED_MOVING = 'PLAYER_STARTED_MOVING',
@@ -290,7 +294,10 @@ local function GlobalConstantProperties(o)
         ZONE_CHANGED_NEW_AREA = 'ZONE_CHANGED_NEW_AREA',
     }
 
+    ---@param msg string Message name
     local function newMsg(msg) return sformat("%s::%s", addon, msg) end
+    ---@param event string Event name
+    local function toMsg(event) return newMsg(event) end
 
     --- @class MessageNames
     local Messages = {
@@ -568,6 +575,7 @@ local function GlobalConstantProperties(o)
     o.UnitClasses = UnitClasses
 
     o.newMsg = newMsg
+    o.toMsg = toMsg
 end
 
 --- @param o GlobalConstants

--- a/Core/Global/GlobalConstants.lua
+++ b/Core/Global/GlobalConstants.lua
@@ -244,12 +244,19 @@ local function GlobalConstantProperties(o)
         --- This event fires whenever there's a change to the player's equipment sets. This includes creating, modifying, or deleting an equipment set.
         EQUIPMENT_SETS_CHANGED = 'EQUIPMENT_SETS_CHANGED',
         --- Triggered after an equipment set swap has been completed. This event helps addons and scripts determine when the gear change process has ended, allowing them to update or react accordingly.
-        --- Event Parameters: result, setID
+        --- Event Params: result, setID
         EQUIPMENT_SWAP_FINISHED = 'EQUIPMENT_SWAP_FINISHED',
         MODIFIER_STATE_CHANGED = 'MODIFIER_STATE_CHANGED',
 
         PET_BATTLE_OPENING_START = 'PET_BATTLE_OPENING_START',
         PET_BATTLE_CLOSE = 'PET_BATTLE_CLOSE',
+
+        --- This event is fired when the players gear changes. Example, a chest is changed to another chest piece.
+        ---
+        --- #### Event Params:<br/>
+        ---  - equipmentSlot number - InventorySlotId
+        ---  - hasCurrent boolean - True when a slot becomes empty, false when filled.
+        PLAYER_EQUIPMENT_CHANGED = 'PLAYER_EQUIPMENT_CHANGED',
 
         PLAYER_CONTROL_GAINED = 'PLAYER_CONTROL_GAINED',
         PLAYER_CONTROL_LOST = 'PLAYER_CONTROL_LOST',
@@ -307,18 +314,19 @@ local function GlobalConstantProperties(o)
         OnAddOnInitializedV2         = newMsg('OnAddOnInitializedV2'),
         OnAddOnReady                 = newMsg('OnAddOnReady'),
         OnBagUpdate                  = newMsg('OnBagUpdate'),
-        OnDBInitialized              = newMsg('OnDBInitialized'),
-        OnConfigInitialized          = newMsg('OnConfigInitialized'),
-        OnTooltipFrameUpdate         = newMsg('OnTooltipFrameUpdate'),
         OnButtonPreClick             = newMsg('OnButtonPreClick'),
         OnButtonPostClick            = newMsg('OnButtonPostClick'),
         OnButtonClickBattlePet       = newMsg('OnButtonClickBattlePet'),
         OnButtonClickEquipmentSet    = newMsg('OnButtonClickEquipmentSet'),
         OnButtonClickCompanion       = newMsg('OnButtonClickCompanion'),
+        OnConfigInitialized          = newMsg('OnConfigInitialized'),
+        OnDBInitialized              = newMsg('OnDBInitialized'),
+        OnEquipmentSetDragComplete   = newMsg('OnEquipmentSetDragComplete'),
         OnMacroAttributesSet         = newMsg('OnMacroAttributesSet'),
         OnUpdateMacroState           = newMsg('OnUpdateMacroState'),
         OnUpdateItemState            = newMsg('OnUpdateItemState'),
         OnSpellCastSucceeded         = newMsg('OnSpellCastSucceeded'),
+        OnTooltipFrameUpdate         = newMsg('OnTooltipFrameUpdate'),
         MacroAttributeSetter_OnSetIcon     = newMsg('MacroAttributeSetter:OnSetIcon'),
         MacroAttributeSetter_OnShowTooltip = newMsg('MacroAttributeSetter:OnShowTooltip'),
         -- External Add-On Integration

--- a/Core/Global/Modules.lua
+++ b/Core/Global/Modules.lua
@@ -66,7 +66,7 @@ local M = {
     EquipmentSetAttributeSetter = '',
     EquipmentSetController = '',
     EquipmentSetDragEventHandler = '',
-    EquipmentSetMixin = '',
+    EquipmentSetButtonMixin = '',
     FrameHandleMixin = '',
     GlobalConstants = '',
     ItemAttributeSetter = '',
@@ -121,7 +121,7 @@ local M = {
 --- @field EquipmentSetAttributeSetter EquipmentSetAttributeSetter
 --- @field EquipmentSetController EquipmentSetController
 --- @field EquipmentSetDragEventHandler EquipmentSetDragEventHandler
---- @field EquipmentSetMixin EquipmentSetMixin
+--- @field EquipmentSetButtonMixin EquipmentSetButtonMixin
 --- @field FrameHandleMixin FrameHandleMixin
 --- @field ItemAttributeSetter ItemAttributeSetter
 --- @field ItemDragEventHandler ItemDragEventHandler

--- a/Core/Global/Modules.lua
+++ b/Core/Global/Modules.lua
@@ -54,14 +54,19 @@ local M = {
     BaseAttributeSetter = '',
     BattlePetAttributeSetter = '',
     BattlePetDragEventHandler = '',
+    BagController = '',
     ButtonFactory = '',
     ButtonFrameFactory = '',
     ButtonUI = '',
     ButtonUIWidgetBuilder = '',
     CompanionAttributeSetter = '',
     CompanionDragEventHandler = '',
+    ConfigDialogController = '',
+    EventToMessageRelayController = '',
     EquipmentSetAttributeSetter = '',
+    EquipmentSetController = '',
     EquipmentSetDragEventHandler = '',
+    EquipmentSetMixin = '',
     FrameHandleMixin = '',
     GlobalConstants = '',
     ItemAttributeSetter = '',
@@ -96,6 +101,7 @@ local M = {
 --- @field ActionType ActionType
 --- @field API API
 --- @field Assert Kapresoft_LibUtil_Assert
+--- @field BagController BagController
 --- @field BaseAPI BaseAPI
 --- @field BaseAttributeSetter BaseAttributeSetter
 --- @field BattlePetAttributeSetter BattlePetAttributeSetter
@@ -108,10 +114,14 @@ local M = {
 --- @field ButtonUIWidgetBuilder ButtonUIWidgetBuilder
 --- @field CompanionAttributeSetter CompanionAttributeSetter
 --- @field CompanionDragEventHandler CompanionDragEventHandler
+--- @field ConfigDialogController ConfigDialogController
 --- @field DebuggingSettingsGroup DebuggingSettingsGroup
 --- @field DruidUnitMixin DruidUnitMixin
+--- @field EventToMessageRelayController EventToMessageRelayController
 --- @field EquipmentSetAttributeSetter EquipmentSetAttributeSetter
+--- @field EquipmentSetController EquipmentSetController
 --- @field EquipmentSetDragEventHandler EquipmentSetDragEventHandler
+--- @field EquipmentSetMixin EquipmentSetMixin
 --- @field FrameHandleMixin FrameHandleMixin
 --- @field ItemAttributeSetter ItemAttributeSetter
 --- @field ItemDragEventHandler ItemDragEventHandler

--- a/Core/Global/Namespace.lua
+++ b/Core/Global/Namespace.lua
@@ -60,6 +60,8 @@ local LogCategories = {
     --- @type LogCategory
     EVENT = "EV",
     --- @type LogCategory
+    EQUIPMENT = "EQ",
+    --- @type LogCategory
     FRAME = "FR",
     --- @type LogCategory
     ITEM = "IT",

--- a/Core/Interface/Interface.lua
+++ b/Core/Interface/Interface.lua
@@ -16,6 +16,8 @@ Aliases
 -------------------------------------------------------------------------------]]
 --- @alias LayoutStrategyFn fun(index:number, barConf:Profile_Bar, context:LayoutStrategyContext)
 
+--- @alias PLAYER_EQUIPMENT_CHANGED_CallbackFn fun(InventorySlotId:Identifier, hasCurrent:boolean) | "function(invSlotID, hasCurrent) end"
+-------------------------------------------------------------------------------]]
 
 --[[-----------------------------------------------------------------------------
 Type: ActionbarPlus_AceDB

--- a/Core/Lib/API/EquipmentSetMixin.lua
+++ b/Core/Lib/API/EquipmentSetMixin.lua
@@ -1,0 +1,132 @@
+--[[-----------------------------------------------------------------------------
+Local Vars
+-------------------------------------------------------------------------------]]
+--- @type Namespace
+local ns = select(2, ...)
+local O, GC, M, LibStub = ns.O, ns.GC, ns.M, ns.LibStub
+
+--[[-----------------------------------------------------------------------------
+New Instance
+-------------------------------------------------------------------------------]]
+--- @return EquipmentSetMixin, LoggerV2
+local function CreateLib()
+    local libName = M.EquipmentSetMixin
+    --- @class EquipmentSetMixin : BaseLibraryObject
+    local newLib = LibStub:NewLibrary(libName); if not newLib then return nil end
+    local logger = ns:CreateDefaultLogger(libName)
+    return newLib, logger
+end; local L, p = CreateLib(); if not L then return end
+
+--[[-----------------------------------------------------------------------------
+Methods
+-------------------------------------------------------------------------------]]
+--- @param o EquipmentSetMixin
+local function PropsAndMethods(o)
+
+    --- @param widget ButtonUIWidget
+    function o:Init(widget)
+        assert(widget, "ButtonUIWidget is missing")
+        self.w = widget
+        self.configData = widget:GetEquipmentSetData()
+        self.baseAPI = O.BaseAPI
+    end
+
+    --- @param widget ButtonUIWidget
+    function o:Mixin(widget) ns:K():Mixin(widget, self:New(widget)) end
+
+    --- @param widget ButtonUIWidget
+    --- @return EquipmentSetMixin
+    function o:New(widget)
+        return ns:K():CreateAndInitFromMixin(o, widget)
+    end
+
+    --- @return boolean, EquipmentSetInfo
+    function o:IsAllEquipped()
+        if self:IsMissingEquipmentSet() then return false end
+        local equipmentSet = self:FindEquipmentSet()
+        local isEquipped = equipmentSet and equipmentSet.isEquipped == true
+        return isEquipped, equipmentSet
+    end
+
+    --- @return EquipmentSetInfo
+    function o:FindEquipmentSet()
+        local id, name = self.configData and self.configData.id, self.configData.name
+        if not id then return end
+
+        local index = self.baseAPI:GetEquipmentSetIndex(id)
+        if not index then return nil end
+
+        local equipmentSet = self.baseAPI:GetEquipmentSetInfoByName(name)
+        if not equipmentSet then
+            equipmentSet = self.baseAPI:GetEquipmentSetInfoBySetID(id)
+        end
+        return equipmentSet
+    end
+
+    --- @return boolean
+    function o:IsMissingEquipmentSet()
+        local d = self.configData
+        local equipmentSetId = d and d.id
+        if not equipmentSetId then return true end
+
+        local equipmentSet = self:FindEquipmentSet()
+        if not equipmentSet then return true end
+
+        local index = self.baseAPI:GetEquipmentSetIndex(equipmentSet.id)
+        if not index then return true end
+
+        return equipmentSet.id ~= equipmentSetId
+    end
+
+    function o:GlowButtonConditionally()
+        local profile = self.w:GetProfileConfig()
+        if profile.equipmentset_show_glow_when_active ~= true then return end
+        self.w:ShowOverlayGlow()
+        C_Timer.After(0.8, function() self.w:HideOverlayGlow() end)
+    end
+
+    --- Note: Equipment Set Name cannot be updated.
+    --- The Equipment Manager always creates a new unique name.
+    function o:UpdateEquipmentSet()
+        -- if index changed (similar to how macros are updated)
+        -- if equipment set was deleted
+        -- icon update
+        if self:IsMissingEquipmentSet() then
+            self.w:SetButtonAsEmpty()
+            self.w:EnableMouse(false)
+            return
+        end
+
+        local equipmentSet = self.w:FindEquipmentSet()
+        if not equipmentSet then
+            self.w:SetButtonAsEmpty()
+            --self.w:SetTextureAsEmpty()
+            return
+        end
+
+        local btnData = self.w:GetEquipmentSetData()
+        btnData.name = equipmentSet.name
+        btnData.icon = equipmentSet.icon
+        self.w:SetIcon(btnData.icon)
+    end
+
+    ---@param setID Identifier Equipment Set ID
+    function o:RefreshTooltip(setID)
+        local equipmentSet = O.BaseAPI:GetEquipmentSetInfoBySetID(setID)
+        if not equipmentSet then return end
+        -- retail GameTooltip uses setID
+        GameTooltip:SetEquipmentSet(equipmentSet.id)
+        local equippedLabel = ns:K().CH:FormatColor('0073FF', ' (Equipped)')
+        GameTooltip:AppendText(equippedLabel)
+    end
+
+    --- @param equipmentData Profile_EquipmentSet
+    --- @param equipmentData Profile_EquipmentSet
+    --- @return boolean
+    function o:IsInvalidEquipmentSet(equipmentData)
+        if not equipmentData then return true end
+        return equipmentData.name and equipmentData.index
+    end
+
+end; PropsAndMethods(L)
+

--- a/Core/Lib/API/_API.xml
+++ b/Core/Lib/API/_API.xml
@@ -6,7 +6,6 @@
     <Script file="DruidUnitMixin.lua"/>
     <Script file="PriestUnitMixin.lua"/>
     <Script file="ShamanUnitMixin.lua"/>
-    <Script file="EquipmentSetMixin.lua"/>
 
     <Script file="APIHooks.lua"/>
     <Script file="BaseAPI.lua"/>

--- a/Core/Lib/API/_API.xml
+++ b/Core/Lib/API/_API.xml
@@ -6,6 +6,7 @@
     <Script file="DruidUnitMixin.lua"/>
     <Script file="PriestUnitMixin.lua"/>
     <Script file="ShamanUnitMixin.lua"/>
+    <Script file="EquipmentSetMixin.lua"/>
 
     <Script file="APIHooks.lua"/>
     <Script file="BaseAPI.lua"/>

--- a/Core/Lib/Interface/CoreInterface.lua
+++ b/Core/Lib/Interface/CoreInterface.lua
@@ -4,7 +4,7 @@ Alias Functions
 --- @alias FrameHandlerFunction fun(fw:FrameWidget) : void | "function(fw) print(fw:GetName()) end"
 --- @alias ButtonPredicateFunction fun(bw:ButtonUIWidget) : boolean | "function(bw) print(bw:GetName()) end"
 --- @alias ButtonHandlerFunction fun(bw:ButtonUIWidget) : void | "function(bw) print(bw:GetName()) end"
---- @alias MessageCallbackFn fun(...:any) | "function() print('Called...') end"
+--- @alias MessageCallbackFn fun(evt:string, source:string, ...:any) | "function(evt, source, ...) print('Called...') end"
 
 --[[-----------------------------------------------------------------------------
 BaseLibraryObject

--- a/Core/Lib/Interface/CoreInterface.lua
+++ b/Core/Lib/Interface/CoreInterface.lua
@@ -4,6 +4,7 @@ Alias Functions
 --- @alias FrameHandlerFunction fun(fw:FrameWidget) : void | "function(fw) print(fw:GetName()) end"
 --- @alias ButtonPredicateFunction fun(bw:ButtonUIWidget) : boolean | "function(bw) print(bw:GetName()) end"
 --- @alias ButtonHandlerFunction fun(bw:ButtonUIWidget) : void | "function(bw) print(bw:GetName()) end"
+--- @alias MessageCallbackFn fun(...:any) | "function() print('Called...') end"
 
 --[[-----------------------------------------------------------------------------
 BaseLibraryObject
@@ -22,6 +23,17 @@ BaseLibraryObject_WithAceEvent
 --- @field name string Retrieves the module's name. This is an instance method that should be implemented to return the name of the module.
 --- @field major string Retrieves the major version of the module. i.e., <LibName>-1.0
 --- @field minor string Retrieves the minor version of the module. i.e., <LibName>-1.0
+--[[-----------------------------------------------------------------------------
+BaseLibraryObject_WithAceEventAndMessage
+-------------------------------------------------------------------------------]]
+--- @class BaseLibraryObject_WithAceEventAndMessage : BaseLibraryObject_WithAceEvent A base library object that includes AceEvent functionality.
+--- @field RegisterAddonMessage fun(self:BaseLibraryObject_WithAceEventAndMessage, fromEvent:string, callback:MessageCallbackFn)
+
+--[[-----------------------------------------------------------------------------
+BaseActionBarController
+-------------------------------------------------------------------------------]]
+--- @class BaseActionBarController : BaseLibraryObject_WithAceEvent A base library object that includes AceEvent functionality.
+--- @field RegisterAddonMessage fun(self:BaseActionBarController, fromEvent:string, callback:MessageCallbackFn)
 
 --[[-----------------------------------------------------------------------------
 BaseLibraryObject_Initialized

--- a/Core/Lib/Widget/ActionBarController.lua
+++ b/Core/Lib/Widget/ActionBarController.lua
@@ -52,35 +52,23 @@ Event Handlers
 -------------------------------------------------------------------------------]]
 local function OnStealthIconUpdate() L:ForEachStealthButton(UpdateIcon) end
 
---- Update Items and Macros referencing items
-local function OnBagUpdate()
-    bagL:t( 'OnBagU(): called..')
-    L:ForEachItemButton(function(bw)
-        local success, itemInfo = safecall(function() return bw:GetItemData() end)
-        if not (success and itemInfo) then return end
-        bw:UpdateItemOrMacroState()
-    end)
-
-    --- @param handlerFn ButtonHandlerFunction
-    local function CallbackFn(handlerFn) ABPI():UpdateM6Macros(handlerFn) end
-    L:SendMessage(MSG.OnBagUpdateExt, libName, CallbackFn)
-end
-
 --- Not fired in classic-era
 local function OnCompanionUpdate()
     L:ForEachCompanionButton(function(bw)
         C_Timer.NewTicker(0.5, function() bw:UpdateCompanionActiveState() end, 3)
     end)
 end
-
+-- TODO: Migrate to a new StealthSpellController, ie. controller:OnStealthIconUpdate()
 local function OnUpdateStealth() OnStealthIconUpdate() end
 local function OnShapeShift()
     C_Timer.NewTicker(0.2, function()
         L:ForEachShapeshiftButton(UpdateIcon)
     end, 2)
 end
+-- TODO: Migrate to a new KeyBindingsController, i.e. controller:UpdateKeyBindings()
 local function OnUpdateBindings() addon():UpdateKeyBindings() end
 
+-- TODO: Migrate to a new "PlayerUnitAuraController", i.e. controller:OnPlayerUnitAura()
 --- @param event string The event name
 local function OnPlayerUnitAura(event, unit)
     ua:t(function() return 'OnPlayerUnitAura(): unit=%s called...', unit end)
@@ -169,8 +157,6 @@ local function PropsAndMethods(o)
         df:f1(function() return 'PLAYER_TARGET_CHANGED: %s', t end)
     end
 
-    o[E.BAG_UPDATE] = OnBagUpdate
-    o[E.BAG_UPDATE_DELAYED] = OnBagUpdate
     o[E.COMPANION_UPDATE] = OnCompanionUpdate
 
     o[E.PLAYER_CONTROL_LOST] = function()
@@ -210,8 +196,6 @@ local function OnAddOnReady(frame)
 
     RegisterFrameForEvents(frame, {
         E.PLAYER_TARGET_CHANGED,
-        E.BAG_UPDATE,
-        E.BAG_UPDATE_DELAYED,
         E.COMPANION_UPDATE,
         E.PLAYER_CONTROL_LOST, E.PLAYER_CONTROL_GAINED,
         E.UPDATE_BINDINGS,

--- a/Core/Lib/Widget/ActionBarController.xml
+++ b/Core/Lib/Widget/ActionBarController.xml
@@ -2,8 +2,19 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
 
+    <Script file="EventToMessageRelayController.lua"/>
+    <Frame name="ABP_EventToMessageRelayControllerFrame">
+        <Scripts>
+            <OnLoad>ABP_H.EventToMessageRelayController_OnLoad(self)</OnLoad>
+            <OnEvent>ABP_H.EventToMessageRelayController_OnEvent(self)</OnEvent>
+        </Scripts>
+    </Frame>
+
     <Script file="ActionBarHandlerMixin.lua"/>
     <Include file="ActionBarFrame.xml"/>
+
+    <Script file="BagController.lua"/>
+    <Script file="EquipmentSetController.lua"/>
 
     <Script file="ActionBarController.lua"/>
     <Frame name="ABP_ActionBarController" parent="UIParent">
@@ -12,4 +23,5 @@
             <OnEvent function="ABP_ActionBarController_OnEvent"/>
         </Scripts>
     </Frame>
+
 </Ui>

--- a/Core/Lib/Widget/ActionBarHandlerMixin.lua
+++ b/Core/Lib/Widget/ActionBarHandlerMixin.lua
@@ -24,10 +24,16 @@ Methods
 -------------------------------------------------------------------------------]]
 ---@param o ActionBarHandlerMixin
 local function PropsAndMethods(o)
+    ---@param bw ButtonUIWidget
     local isCompanionFn = function(bw) return bw:IsCompanionWOTLK() end
+    ---@param bw ButtonUIWidget
     local isShapeShiftFn = function(bw) return bw:IsShapeshiftSpell() end
+    ---@param bw ButtonUIWidget
     local isStealthSpellFn = function(bw) return bw:IsStealthSpell() end
+    ---@param bw ButtonUIWidget
     local isItemOrMacroFn = function(bw) return bw:IsItemOrMacro() end
+    ---@param bw ButtonUIWidget
+    local isEquipmentSetFn = function(bw) return bw:IsEquipmentSet() end
 
     --- @return any The embedded object (same as what was passed)
     --- @param obj any The object to embed
@@ -48,7 +54,7 @@ local function PropsAndMethods(o)
     function o:ForEachButton(applyFn, predicateFn)
         self:ForEachVisibleFrames(function(fw)
             for _, btn in ipairs(fw.buttonFrames) do
-                local shouldApply = predicateFn and predicateFn(btn.widget)
+                local shouldApply = btn.widget and predicateFn and predicateFn(btn.widget)
                 if true == shouldApply then applyFn(btn.widget) end
             end
         end)
@@ -84,6 +90,12 @@ local function PropsAndMethods(o)
     function o:ForEachMatchingSpellButton(matchSpellId, applyFn)
         assert(applyFn, "ForEachMatchingSpellButton(fn):: Function handler missing")
         self:ForEachButton(applyFn, function(bw) return bw:IsMatchingMacroOrSpell(matchSpellId) end)
+    end
+
+    --- @param applyFn ButtonHandlerFunction | "function(bw) print(bw:GetName()) end"
+    function o:ForEachEquipmentSetButton(applyFn)
+        assert(applyFn, "ForEachEquipmentSetButton(fn):: Function handler missing")
+        self:ForEachButton(applyFn, isEquipmentSetFn)
     end
 
 end;

--- a/Core/Lib/Widget/ActionbarPlusEventMixin.lua
+++ b/Core/Lib/Widget/ActionbarPlusEventMixin.lua
@@ -215,7 +215,6 @@ function L:RegisterEventToMessageTransmitter()
     --- @see GlobalConstants#M (Messages)
     RegisterFrameForEvents(f, {
         E.PLAYER_ENTERING_WORLD,
-        E.EQUIPMENT_SETS_CHANGED, E.EQUIPMENT_SWAP_FINISHED,
         E.PLAYER_MOUNT_DISPLAY_CHANGED, E.ZONE_CHANGED_NEW_AREA,
         E.MODIFIER_STATE_CHANGED,
         E.CVAR_UPDATE,

--- a/Core/Lib/Widget/BagController.lua
+++ b/Core/Lib/Widget/BagController.lua
@@ -1,0 +1,49 @@
+--- @alias BagController __BagController | ActionBarHandlerMixin
+--[[-----------------------------------------------------------------------------
+Local Vars
+-------------------------------------------------------------------------------]]
+--- @type Namespace
+local ns = select(2, ...)
+local O, GC, E, MSG = ns.O, ns.GC, ns.GC.E, ns.GC.M
+
+local libName = ns.M.BagController
+local safecall = ns:CreateSafecall(libName)
+--[[-----------------------------------------------------------------------------
+New Instance
+-------------------------------------------------------------------------------]]
+--- @class __BagController : BaseActionBarController
+local L = ns:NewActionBarHandler(libName, O.ActionBarHandlerMixin)
+local p = ns:CreateDefaultLogger(libName)
+local pb = ns:LC().BAG:NewLogger(libName)
+
+--[[-----------------------------------------------------------------------------
+Methods
+-------------------------------------------------------------------------------]]
+---@param o __BagController | BagController
+local function PropsAndMethods(o)
+
+    local function extAPI() return O.ActionbarPlusAPI  end
+
+    --- @private
+    function o:RegisterMessageCallbacks()
+        self:RegisterAddonMessage(E.BAG_UPDATE, function(evt, source) self:OnBagUpdate(evt, source) end)
+    end
+
+    -- Update Items and Macros referencing items
+    function o:OnBagUpdate(evt)
+        pb:f3( function() return 'OnBagU(): called...' end)
+        self:ForEachItemButton(function(bw)
+            local success, itemInfo = safecall(function() return bw:GetItemData() end)
+            if not (success and itemInfo) then return end
+            bw:UpdateItemOrMacroState()
+        end)
+
+        --- @param handlerFn ButtonHandlerFunction
+        local function CallbackFn(handlerFn) extAPI():UpdateM6Macros(handlerFn) end
+        self:SendMessage(MSG.OnBagUpdateExt, libName, CallbackFn)
+    end
+
+    o:RegisterMessageCallbacks()
+
+end; PropsAndMethods(L)
+

--- a/Core/Lib/Widget/Buttons/BaseAttributeSetter.lua
+++ b/Core/Lib/Widget/Buttons/BaseAttributeSetter.lua
@@ -33,7 +33,8 @@ local p = ns:LC().BUTTON:NewLogger(M.BaseAttributeSetter)
 --[[-----------------------------------------------------------------------------
 Support Functions
 -------------------------------------------------------------------------------]]
---- @param btnUI ButtonUI
+-- todo: delete PostCombat. This was for dragging buttons during combat. That is no longer allowed.
+--- @param btn ButtonUI
 local function AddPostCombat(btn)
     if not InCombatLockdown() then return end
     O.ButtonFrameFactory:AddPostCombatUpdate(btn.widget)
@@ -62,7 +63,8 @@ Methods
 -------------------------------------------------------------------------------]]
 --- @param btn ButtonUI
 function L:OnAfterSetAttributes(btn)
-    AddPostCombat(btn)
+    -- todo: delete PostCombat. This was for dragging buttons during combat. That is no longer allowed.
+    -- AddPostCombat(btn)
     self:HandleGameTooltipCallbacks(btn)
 end
 
@@ -77,9 +79,9 @@ function L:HandleGameTooltipCallbacks(btn)
         else
             if not w:IsTooltipModifierKeyDown() then return end
         end
-        local btn = w.button()
-        self:SetToolTipOwner(btn)
-        self:ShowTooltip(btn)
+        local btnF = w.button()
+        self:SetToolTipOwner(btnF)
+        self:ShowTooltip(btnF)
 
         if not GetCursorInfo() then return end
         w:SetHighlightEmptyButtonEnabled(true)

--- a/Core/Lib/Widget/Buttons/ButtonFrameFactory.lua
+++ b/Core/Lib/Widget/Buttons/ButtonFrameFactory.lua
@@ -75,21 +75,6 @@ local function EnableMouseAllButtons(frameWidget, state)
         bw:EnableMouse(state)
     end)
 end
---- @param frameWidget FrameWidget
---- @param event string
-local function OnEquipmentSetsChanged(frameWidget, event)
-    frameWidget:ApplyForEachButtonCondition(function(btnWidget) return btnWidget:IsEquipmentSet() end,
-            function(btnWidget) btnWidget:UpdateEquipmentSet() end)
-end
-
---- @param frameWidget FrameWidget
---- @param event string
-local function OnEquipmentSwapFinished(frameWidget, event)
-    frameWidget:ApplyForEachButtonCondition(function(btnWidget) return btnWidget:IsEquipmentSet() end,
-            function(btnWidget)
-                O.EquipmentSetAttributeSetter:RefreshTooltipAtMouse(btnWidget.button())
-            end)
-end
 
 --- @param frameWidget FrameWidget
 --- @param event string
@@ -243,8 +228,6 @@ local function RegisterCallbacks(widget)
     --- Use new AceEvent each time or else, the message handler will only be called once
     local AceEventIC = ns:AceEvent()
     AceEventIC:RegisterMessage(M.OnAddOnReady, function(msg) OnAddOnReady(widget, msg) end)
-    AceEventIC:RegisterMessage(M.EQUIPMENT_SETS_CHANGED, function(evt) OnEquipmentSetsChanged(widget, evt) end)
-    AceEventIC:RegisterMessage(M.EQUIPMENT_SWAP_FINISHED, function(evt) OnEquipmentSwapFinished(widget, evt) end)
     AceEventIC:RegisterMessage(M.MODIFIER_STATE_CHANGED, function(evt, ...) OnModifierStateChanged(widget, evt, ...) end)
     widget:SetCallback(E.OnCooldownTextSettingsChanged, OnCooldownTextSettingsChanged)
     widget:SetCallback(E.OnTextSettingsChanged, OnTextSettingsChanged)

--- a/Core/Lib/Widget/Buttons/ButtonFrameFactory.lua
+++ b/Core/Lib/Widget/Buttons/ButtonFrameFactory.lua
@@ -208,7 +208,8 @@ end
 --- @param frameWidget FrameWidget
 local function OnPlayerLeaveCombat(frameWidget, e, ...)
     OnActionbarShowGroup(frameWidget, e, ...)
-    L:PostCombatUpdateComplete()
+    -- todo: delete PostCombat. This was for dragging buttons during combat. That is no longer allowed.
+    -- L:PostCombatUpdateComplete()
 end
 
 --- @param frameWidget FrameWidget
@@ -703,9 +704,11 @@ function L:IsFrameShownByIndex(frameIndex)
     return self:GetFrameByIndex(frameIndex):IsShown()
 end
 
+-- todo: delete PostCombat. This was for dragging buttons during combat. That is no longer allowed.
 --- @param btnWidget ButtonUIWidget
 function L:AddPostCombatUpdate(btnWidget) table.insert(PostCombatButtonUpdates, btnWidget) end
 
+-- todo: delete this. This was for dragging buttons during combat. That is no longer allowed.
 function L:PostCombatUpdateComplete()
     local count = #PostCombatButtonUpdates
     if count <= 0 then return end

--- a/Core/Lib/Widget/Buttons/ButtonMixin.lua
+++ b/Core/Lib/Widget/Buttons/ButtonMixin.lua
@@ -296,9 +296,11 @@ local function PropsAndMethods(o)
         self:ResetWidgetAttributes()
     end
 
+    --- Note: Don't call self:EnableMouse(..) here
     function o:SetButtonAsEmpty()
         self:ResetConfig()
         self:SetTextureAsEmpty()
+        self:SetChecked(false)
     end
 
     function o:Reset()
@@ -645,23 +647,6 @@ local function PropsAndMethods(o)
         self:SetCooldown(cd.start, cd.duration)
     end
     function o:UpdateCooldownDelayed(inSeconds) C_Timer.After(inSeconds, function() self:UpdateCooldown() end) end
-
-    --- Note: Equipment Set Name cannot be updated.
-    --- The Equipment Manager always creates a new unique name.
-    function o:UpdateEquipmentSet()
-        -- if index changed (similar to how macros are updated)
-        -- if equipment set was deleted
-        -- icon update
-        if self:IsMissingEquipmentSet() then self:SetButtonAsEmpty(); return end
-
-        local equipmentSet = self.w:FindEquipmentSet()
-        if not equipmentSet then self:SetButtonAsEmpty(); return end
-
-        local btnData = self.w:GetEquipmentSetData()
-        btnData.name = equipmentSet.name
-        btnData.icon = equipmentSet.icon
-        self:SetIcon(btnData.icon)
-    end
 
     --- IsSpellOverlayed() is available in Retail Version
     function o:UpdateGlow()
@@ -1183,6 +1168,18 @@ local function PropsAndMethods(o)
             return
         end
         self:ShowOverlayGlowAsActiveButton()
+    end
+
+    --- @return EquipmentSetMixin
+    function o:EquipmentSet() return O.EquipmentSetMixin:New(self.w) end
+
+    function o:IsChecked() return self.button().CheckedTexture:IsShown() end
+    ---@param checked boolean
+    function o:SetChecked(checked)
+        if checked then
+            self.button().CheckedTexture:Show(); return
+        end
+        return self.button().CheckedTexture:Hide()
     end
 
 end

--- a/Core/Lib/Widget/Buttons/ButtonMixin.lua
+++ b/Core/Lib/Widget/Buttons/ButtonMixin.lua
@@ -1170,8 +1170,8 @@ local function PropsAndMethods(o)
         self:ShowOverlayGlowAsActiveButton()
     end
 
-    --- @return EquipmentSetMixin
-    function o:EquipmentSet() return O.EquipmentSetMixin:New(self.w) end
+    --- @return EquipmentSetButtonMixin
+    function o:EquipmentSetMixin() return O.EquipmentSetButtonMixin:New(self.w) end
 
     function o:IsChecked() return self.button().CheckedTexture:IsShown() end
     ---@param checked boolean

--- a/Core/Lib/Widget/Buttons/ButtonProfileMixin.lua
+++ b/Core/Lib/Widget/Buttons/ButtonProfileMixin.lua
@@ -332,44 +332,12 @@ local function PropsAndMethods(o)
     function o:IsInvalidCompanion(c)
         return IsNil(c) or (IsNil(c.name) and IsNil(c.spell) and IsNil(c.spell.id))
     end
-    --- @param e Profile_EquipmentSet
-    function o:IsInvalidEquipmentSet(e)
-        e = e or self:GetEquipmentSetData()
-        if not e then return true end
-        return IsNil(e) or (IsNil(e.name) and IsNil(e.index)) end
 
     --- @param pet Profile_BattlePet
     function o:IsInvalidBattlePet(pet) return IsNil(pet) or (IsNil(pet.guid) and IsNil(pet.name)) end
     function o:IsShowIndex() return P:IsShowIndex(self.w.frameIndex) end
     function o:IsShowEmptyButtons() return P:IsShowEmptyButtons(self.w.frameIndex) end
     function o:IsShowKeybindText() return P:IsShowKeybindText(self.w.frameIndex) end
-
-    --- @return EquipmentSetInfo
-    function o:FindEquipmentSet()
-        local btnData = self:GetEquipmentSetData()
-        if not btnData then return nil end
-
-        local id, name = btnData.id, btnData.name
-        local index = BaseAPI:GetEquipmentSetIndex(id)
-        if not index then return nil end
-
-        local equipmentSet = BaseAPI:GetEquipmentSetInfoByName(name)
-        if not equipmentSet then
-            equipmentSet = BaseAPI:GetEquipmentSetInfoBySetID(id)
-        end
-        return equipmentSet
-    end
-
-    function o:IsMissingEquipmentSet()
-        if self:IsInvalidEquipmentSet() then return true end
-        local equipmentSet = self:FindEquipmentSet()
-        if not equipmentSet then return true end
-
-        local index = BaseAPI:GetEquipmentSetIndex(equipmentSet.id)
-        if not index then return true end
-
-        return equipmentSet.id ~= self:GetEquipmentSetData().id
-    end
 
     function o:ResetButtonData()
         local conf = self:conf()

--- a/Core/Lib/Widget/Buttons/ButtonUI.lua
+++ b/Core/Lib/Widget/Buttons/ButtonUI.lua
@@ -24,10 +24,11 @@ New Instance
 --- @class ButtonUIWidgetBuilder : WidgetMixin
 local _B = LibStub:NewLibrary(M.ButtonUIWidgetBuilder)
 
+local libName = M.ButtonUI
 --- @class ButtonUILib
-local _L = LibStub:NewLibrary(M.ButtonUI, 1)
-local p = ns:LC().BUTTON:NewLogger(M.ButtonUI)
-local pd = ns:LC().DRAG_AND_DROP:NewLogger(M.ButtonUI)
+local _L = LibStub:NewLibrary(libName, 1)
+local p = ns:LC().BUTTON:NewLogger(libName)
+local pd = ns:LC().DRAG_AND_DROP:NewLogger(libName)
 
 --- @return ButtonUIWidgetBuilder
 function _L:WidgetBuilder() return _B end
@@ -86,7 +87,7 @@ local function OnPreClick(btn, key, down)
         w:SendMessage(GC.M.OnButtonClickBattlePet, w)
         return
     elseif w:IsEquipmentSet() then
-        w:SendMessage(GC.M.OnButtonClickEquipmentSet, w)
+        w:SendMessage(GC.M.OnButtonClickEquipmentSet, libName, w)
         return
     else
         w:UpdateRangeIndicator()
@@ -387,7 +388,7 @@ function _B:Create(dragFrameWidget, rowNum, colNum, btnIndex)
 
     self:CreateCheckedTexture(button)
 
-    --- @alias ButtonUIWidget __ButtonUIWidget | BaseLibraryObject_WithAceEvent | ButtonMixin | EquipmentSetMixin
+    --- @alias ButtonUIWidget __ButtonUIWidget | BaseLibraryObject_WithAceEvent | ButtonMixin
     --- @class __ButtonUIWidget
     local __widget = {
         --- @type fun() : ActionbarPlus

--- a/Core/Lib/Widget/Buttons/ButtonUI.lua
+++ b/Core/Lib/Widget/Buttons/ButtonUI.lua
@@ -348,6 +348,8 @@ function _B:Create(dragFrameWidget, rowNum, colNum, btnIndex)
     local btnName = GC:ButtonName(dragFrameWidget.index, btnIndex)
 
     --- @class __ButtonUI
+    --- @field CheckedTexture _Texture
+    --- @field Cooldown _CooldownFrame
     local button = CreateFrame("Button", btnName, UIParent, GC.C.SECURE_ACTION_BUTTON_TEMPLATE)
     --- @alias ButtonUI __ButtonUI|_Button
 
@@ -373,6 +375,7 @@ function _B:Create(dragFrameWidget, rowNum, colNum, btnIndex)
     --- see: Interface/AddOns/Blizzard_APIDocumentationGenerated/CooldownFrameAPIDocumentation.lua
     --- @class CooldownFrame : _CooldownFrame
     local cooldown = CreateFrame("Cooldown", btnName .. 'Cooldown', button,  "CooldownFrameTemplate")
+    cooldown:SetParentKey('Cooldown')
     cooldown:SetAllPoints(button)
     cooldown:SetSwipeColor(1, 1, 1)
     cooldown:SetCountdownFont(GameFontHighlightSmallOutline:GetFont())
@@ -382,8 +385,10 @@ function _B:Create(dragFrameWidget, rowNum, colNum, btnIndex)
     cooldown:SetUseCircularEdge(false)
     cooldown:SetPoint('CENTER')
 
-    --- @alias ButtonUIWidget __ButtonUIWidget | BaseLibraryObject_WithAceEvent
-    --- @class __ButtonUIWidget : ButtonMixin
+    self:CreateCheckedTexture(button)
+
+    --- @alias ButtonUIWidget __ButtonUIWidget | BaseLibraryObject_WithAceEvent | ButtonMixin | EquipmentSetMixin
+    --- @class __ButtonUIWidget
     local __widget = {
         --- @type fun() : ActionbarPlus
         addon = function() return ABP end,
@@ -425,4 +430,18 @@ function _B:Create(dragFrameWidget, rowNum, colNum, btnIndex)
     widget:InitWidget()
 
     return widget
+end
+
+--- @param button __ButtonUI
+function _B:CreateCheckedTexture(button)
+    local checkedTexture = button:CreateTexture(nil, "OVERLAY")
+    checkedTexture:SetAllPoints() -- Make the texture cover the whole button
+    checkedTexture:SetTexture("Interface\\Buttons\\CheckButtonHilight")
+    checkedTexture:SetBlendMode("ADD") -- This corresponds to alphaMode="ADD" in XML
+    -- set ignore alpha to false so we can control it via settings
+    checkedTexture:SetIgnoreParentAlpha(false)
+    checkedTexture:SetIgnoreParentScale(false)
+    checkedTexture:EnableMouse(false)
+    checkedTexture:SetParentKey("CheckedTexture")
+    checkedTexture:Hide()
 end

--- a/Core/Lib/Widget/Buttons/EquipmentSetButtonMixin.lua
+++ b/Core/Lib/Widget/Buttons/EquipmentSetButtonMixin.lua
@@ -8,10 +8,10 @@ local O, GC, M, LibStub = ns.O, ns.GC, ns.M, ns.LibStub
 --[[-----------------------------------------------------------------------------
 New Instance
 -------------------------------------------------------------------------------]]
---- @return EquipmentSetMixin, LoggerV2
+--- @return EquipmentSetButtonMixin, LoggerV2
 local function CreateLib()
-    local libName = M.EquipmentSetMixin
-    --- @class EquipmentSetMixin : BaseLibraryObject
+    local libName = M.EquipmentSetButtonMixin
+    --- @class EquipmentSetButtonMixin : BaseLibraryObject
     local newLib = LibStub:NewLibrary(libName); if not newLib then return nil end
     local logger = ns:CreateDefaultLogger(libName)
     return newLib, logger
@@ -20,7 +20,7 @@ end; local L, p = CreateLib(); if not L then return end
 --[[-----------------------------------------------------------------------------
 Methods
 -------------------------------------------------------------------------------]]
---- @param o EquipmentSetMixin
+--- @param o EquipmentSetButtonMixin
 local function PropsAndMethods(o)
 
     --- @param widget ButtonUIWidget
@@ -35,7 +35,7 @@ local function PropsAndMethods(o)
     function o:Mixin(widget) ns:K():Mixin(widget, self:New(widget)) end
 
     --- @param widget ButtonUIWidget
-    --- @return EquipmentSetMixin
+    --- @return EquipmentSetButtonMixin
     function o:New(widget)
         return ns:K():CreateAndInitFromMixin(o, widget)
     end
@@ -97,10 +97,9 @@ local function PropsAndMethods(o)
             return
         end
 
-        local equipmentSet = self.w:FindEquipmentSet()
+        local equipmentSet = self:FindEquipmentSet()
         if not equipmentSet then
             self.w:SetButtonAsEmpty()
-            --self.w:SetTextureAsEmpty()
             return
         end
 

--- a/Core/Lib/Widget/Buttons/EquipmentSetDragEventHandler.lua
+++ b/Core/Lib/Widget/Buttons/EquipmentSetDragEventHandler.lua
@@ -8,8 +8,6 @@ Blizzard Vars
 -------------------------------------------------------------------------------]]
 --- @type __GameTooltip
 local GameTooltip = GameTooltip
----### See: Interface/SharedXML/Constants.lua
-local DESC_FORMAT = HIGHLIGHT_FONT_COLOR_CODE .. '\n%s' .. FONT_COLOR_CODE_CLOSE
 
 --[[-----------------------------------------------------------------------------
 Local Vars
@@ -20,15 +18,14 @@ local O, GC, M, LibStub = ns.O, ns.GC, ns.M, ns.LibStub
 
 local BaseAPI, PH = O.BaseAPI, O.PickupHandler
 local WAttr, EMPTY_ICON = GC.WidgetAttributes, GC.Textures.TEXTURE_EMPTY
-
+local AceEvent = ns:AceEvent()
+local libName = M.EquipmentSetDragEventHandler
 --[[-----------------------------------------------------------------------------
 New Instance
 -------------------------------------------------------------------------------]]
 --- @class EquipmentSetDragEventHandler : DragEventHandler
-local L = LibStub:NewLibrary(M.EquipmentSetDragEventHandler)
-
-local p = ns:LC().DRAG_AND_DROP:NewLogger(M.EquipmentSetDragEventHandler)
-local pe = ns:LC().EVENT:NewLogger(M.EquipmentSetDragEventHandler)
+local L = LibStub:NewLibrary(libName)
+local p = ns:LC().DRAG_AND_DROP:NewLogger(libName)
 
 --- @class EquipmentSetAttributeSetter : BaseAttributeSetter
 local S = LibStub:NewLibrary(M.EquipmentSetAttributeSetter)
@@ -49,71 +46,6 @@ local function ToProfileEquipmentSet(equipmentSet)
         id = equipmentSet.id,
         icon = equipmentSet.icon,
     }
-end
-
---- @param w ButtonUIWidget
-local function ClickEquipmentSetButton(w)
-    if w:EquipmentSet():IsMissingEquipmentSet() then return end
-
-    local equipmentSet = w:GetEquipmentSetData()
-    local index = BaseAPI:GetEquipmentSetIndex(equipmentSet.id)
-
-    local btnName = 'GearSetButton' .. (index)
-    if _G[btnName] then _G[btnName]:Click() end
-end
---- @param w ButtonUIWidget
-local function ClickEquipmentSetButtonDelayed(w)
-    C_Timer.After(0.2, function() ClickEquipmentSetButton(w) end)
-end
-
---- @param w ButtonUIWidget
----@param profile Profile_Config
-local function OpenEquipmentMgrConditionally(w, profile)
-    if profile.equipmentset_open_equipment_manager == true then
-        --- @type _Frame
-        local gmDlg = GearManagerDialog
-        if gmDlg and gmDlg:IsVisible() then ClickEquipmentSetButtonDelayed(w) return end
-    end
-
-    --- Buttons:
-    --- • GearManagerToggleButton (pre-retail)
-    --- • PaperDollSidebarTab3 (retail)
-    --- @type _Button
-    local gmButton = GearManagerToggleButton or PaperDollSidebarTab3
-    if profile.equipmentset_open_equipment_manager ~= true then return end
-    C_Timer.After(0.1, function()
-        gmButton:Click()
-        ClickEquipmentSetButtonDelayed(w)
-    end)
-end
-
---- @param w ButtonUIWidget
-local function GlowButtonConditionally(w)
-    local profile = w:GetProfileConfig()
-    if profile.equipmentset_show_glow_when_active ~= true then return end
-    w:ShowOverlayGlow()
-    C_Timer.After(0.8, function() w:HideOverlayGlow() end)
-end
-
---- @param evt string
---- @param w ButtonUIWidget
-local function OnClick(evt, w, ...)
-    assert(w, "ButtonUIWidget is missing")
-    pe:d(function() return 'Message[%s]: %s', evt, w:GetName() end)
-    if not w:CanChangeEquipmentSet() or InCombatLockdown() then return end
-
-    --- @type _Frame
-    local PDF = PaperDollFrame
-    C_EquipmentSet.UseEquipmentSet(w:GetEquipmentSetData().id)
-    PlaySound(SOUNDKIT.GUILD_BANK_OPEN_BAG)
-
-    local profile = w:GetProfileConfig()
-    if profile.equipmentset_open_character_frame then
-        if not PDF:IsVisible() then
-            ToggleCharacter('PaperDollFrame')
-            OpenEquipmentMgrConditionally(w, profile)
-        else OpenEquipmentMgrConditionally(w, profile) end
-    end
 end
 
 --[[-----------------------------------------------------------------------------
@@ -148,6 +80,8 @@ local function eventHandlerMethods(e)
         config[WAttr.EQUIPMENT_SET] = equipmentSet
 
         S(btnUI, config)
+
+        AceEvent:SendMessage(GC.M.OnEquipmentSetDragComplete, libName, btnUI.widget)
     end
 
 end
@@ -163,7 +97,7 @@ local function attributeSetterMethods(a)
         local w = btnUI.widget; if not w then return end
         w:ResetWidgetAttributes()
         local equipmentSet = w:GetEquipmentSetData()
-        if w:EquipmentSet():IsInvalidEquipmentSet(equipmentSet) then return end
+        if w:EquipmentSetMixin():IsInvalidEquipmentSet(equipmentSet) then return end
 
         local icon = EMPTY_ICON
         if equipmentSet.icon then icon = equipmentSet.icon end
@@ -180,9 +114,6 @@ local function attributeSetterMethods(a)
         if f:GetName() ~= btnUI:GetName() then return end
 
         self:RefreshTooltip(f)
-        local w = btnUI.widget
-        local profile = w:GetProfileConfig()
-        --GlowButtonConditionally(w, profile)
     end
 
     --- @param btnUI ButtonUI
@@ -194,7 +125,7 @@ local function attributeSetterMethods(a)
     function a:ShowTooltip(btnUI, setID)
         if not btnUI then return end
         local w = btnUI.widget; if w:IsEmpty() then return end
-        local es = w:EquipmentSet()
+        local es = w:EquipmentSetMixin()
         if es:IsMissingEquipmentSet() then return end
         local equipmentSet = es:FindEquipmentSet()
         -- retail GameTooltip uses setID
@@ -219,8 +150,4 @@ local function Init()
 
     S.mt.__index = BaseAttributeSetter
     S.mt.__call = S.SetAttributes
-
-    ns:AceEvent():RegisterMessage(GC.M.OnButtonClickEquipmentSet, OnClick)
-end
-
-Init()
+end; Init()

--- a/Core/Lib/Widget/Buttons/_Buttons.xml
+++ b/Core/Lib/Widget/Buttons/_Buttons.xml
@@ -17,6 +17,7 @@
     <Script file="CompanionDragEventHandler.lua"/>
     <Script file="BattlePetDragEventHandler.lua"/>
     <Script file="EquipmentSetDragEventHandler.lua"/>
+    <Script file="EquipmentSetButtonMixin.lua"/>
     <Script file="ReceiveDragEventHandler.lua"/>
     <Script file="ButtonFactory.lua"/>
 

--- a/Core/Lib/Widget/ConfigDialogController.lua
+++ b/Core/Lib/Widget/ConfigDialogController.lua
@@ -1,0 +1,49 @@
+--[[-----------------------------------------------------------------------------
+Local Vars
+-------------------------------------------------------------------------------]]
+--- @type Namespace
+local ns = select(2, ...)
+local O, MS = ns.O, ns.GC.M
+local AceConfigDialog = O.AceLibrary.AceConfigDialog
+local libName = ns.M.ConfigDialogController
+--[[-----------------------------------------------------------------------------
+New Instance
+-------------------------------------------------------------------------------]]
+--- @class ConfigDialogController : BaseLibraryObject_WithAceEvent
+local L = ns:NewLibXEvent(O.ConfigDialogController, libName)
+local p = ns:CreateDefaultLogger(libName)
+local pt = ns:LC().TRACE:NewLogger(libName)
+
+--[[-----------------------------------------------------------------------------
+Methods
+-------------------------------------------------------------------------------]]
+---@param o ConfigDialogController
+local function PropsAndMethods(o)
+
+    function o:OnAddonReady()
+        if ns.ConfigDialogControllerEventFrame then
+            pt:f1('ConfigDialogControllerEventFrame already initialized...')
+            return;
+        end
+        self:CreateDialogEventFrame()
+    end
+
+    function o:CreateDialogEventFrame()
+        pt:f1(function() return 'CreateDialogEventFrame called with ConfigDialogControllerEventFrame: %s', type(ns.ConfigDialogControllerEventFrame) end)
+        local frameName = ns.sformat("%s_%sEventFrame", ns.name, libName)
+        --- @class ConfigDialogControllerEventFrame: _Frame
+        local f = CreateFrame("Frame", frameName, UIParent, "SecureHandlerStateTemplate")
+        f:Hide()
+        f:SetScript("OnHide", function(self)
+            if not AceConfigDialog.OpenFrames[ns.name] then return end
+            AceConfigDialog:Close(ns.name)
+        end)
+        ns.ConfigDialogControllerEventFrame = f
+        RegisterStateDriver(f, "visibility", "[combat]hide;show")
+    end
+
+    L:RegisterMessage(MS.OnAddOnReady, function() o:OnAddonReady()  end)
+
+end; PropsAndMethods(L)
+
+

--- a/Core/Lib/Widget/EquipmentSetController.lua
+++ b/Core/Lib/Widget/EquipmentSetController.lua
@@ -6,53 +6,72 @@ Local Vars
 local ns = select(2, ...)
 local O, GC, MSG, E = ns.O, ns.GC, ns.GC.M, ns.GC.E
 
-local AceBucket = ns:AceBucket()
-local toMsg = GC.toMsg
-local ES = O.EquipmentSetMixin
-local libName = 'EquipmentSetController'
+local BaseAPI = O.BaseAPI
+local libName = ns.M.EquipmentSetController
 --[[-----------------------------------------------------------------------------
 New Instance
 -------------------------------------------------------------------------------]]
 --- @class __EquipmentSetController : BaseActionBarController
 local L = ns:NewActionBarHandler(libName);
-local p = ns:CreateDefaultLogger(libName)
-p:v(function() return "Loaded: %s", libName end)
+local p = ns:LC().EQUIPMENT:NewLogger(libName)
+local pd = ns:CreateDefaultLogger(libName)
 
 --[[-----------------------------------------------------------------------------
 Methods
 -------------------------------------------------------------------------------]]
----@param o __EquipmentSetController | EquipmentSetController
+--- @param o __EquipmentSetController | EquipmentSetController
 local function PropsAndMethods(o)
 
     --- @private
     function o:RegisterMessageCallbacks()
         self:RegisterMessage(MSG.OnAddOnReady, function() self:OnAddOnReady()  end)
-        self:RegisterAddonMessage(E.EQUIPMENT_SETS_CHANGED, function(evt) self:OnEquipmentSetsChanged() end)
-        self:RegisterAddonMessage(E.EQUIPMENT_SWAP_FINISHED, function(evt, source, success, setID)
-            self:OnEquipmentSwapFinished(success, setID) end)
+        self:RegisterMessage(GC.M.OnButtonClickEquipmentSet,
+                function(evt, source, ...) self:OnClick(...)  end)
+        self:RegisterMessage(GC.M.OnEquipmentSetDragComplete,
+                function(evt, source, ...) self:OnEquipmentSetDragComplete(...)  end)
+        self:RegisterAddonMessage(E.PLAYER_EQUIPMENT_CHANGED,
+                function(evt, source, ...) self:OnPlayerEquipmentChanged(...) end)
+        self:RegisterAddonMessage(E.EQUIPMENT_SETS_CHANGED,
+                function(evt) self:OnEquipmentSetsChanged() end)
+        self:RegisterAddonMessage(E.EQUIPMENT_SWAP_FINISHED,
+                function(evt, source, success, setID) self:OnEquipmentSwapFinished(success, setID) end)
     end
 
+    --- @private
+    --- @param bw ButtonUIWidget
+    function o:OnEquipmentSetDragComplete(bw)
+        local name = bw and bw:GN()
+        p:f3(function()
+            return 'OnEquipmentSetDragComplete called: widget=%s', name end)
+        self:CheckIfEquipped(bw:EquipmentSetMixin())
+    end
+
+    --- @private
+    --- @param invSlotID Identifier
+    --- @param hasCurrent boolean True when a slot becomes empty, false when filled.
+    function o:OnPlayerEquipmentChanged(invSlotID, hasCurrent)
+        p:f3(function()
+            return 'OnPlayerEquipmentChanged called: slotID=%s hasCurrent=%s', invSlotID, tostring(hasCurrent) end)
+        self:ConditionallyCheckButtons()
+    end
+
+    --- @private
     function o:OnAddOnReady()
         p:f3('OnEquipmentSetsChanged called...')
-
-        self:ForEachEquipmentSetButton(function(bw)
-            local equipped, set = ES:New(bw):IsAllEquipped()
-            p:d(function() return 'Is-Equipped::%s[%s]?: %s',
-                bw:GN(), set.name ,tostring(equipped) end)
-            bw:SetChecked(equipped)
-        end)
+        self:ConditionallyCheckButtons()
     end
 
-    --- @param frameWidget FrameWidget
-    --- @param event string
+    --- Called when an equipment-set is saved, deleted, renamed
     --- @private
-    function o:OnEquipmentSetsChanged(frameWidget, event)
+    function o:OnEquipmentSetsChanged()
         p:f3('OnEquipmentSetsChanged called...')
         self:ForEachEquipmentSetButton(function(bw)
-            ES:New(bw):UpdateEquipmentSet()
+            bw:EquipmentSetMixin():UpdateEquipmentSet()
         end)
+        self:ConditionallyCheckButtons()
     end
 
+    --- @private
     --- @param success boolean
     --- @param setID Identifier
     function o:OnEquipmentSwapFinished(success, setID)
@@ -60,14 +79,89 @@ local function PropsAndMethods(o)
                 tostring(success), tostring(setID) end)
 
         self:ForEachEquipmentSetButton(function(bw)
-            local es = ES:New(bw)
+            local es = bw:EquipmentSetMixin()
             es:RefreshTooltip(setID)
+            self:CheckIfEquipped(es)
             local d = bw:GetEquipmentSetData()
-            if d.id ~= setID then return bw:SetChecked(false) end
-
+            if d.id ~= setID then return end
             es:GlowButtonConditionally()
-            bw:SetChecked(true)
         end)
+    end
+
+    --- @private
+    --- @param w ButtonUIWidget
+    function o:OnClick(w)
+        assert(w, "ButtonUIWidget is missing")
+        if not w:CanChangeEquipmentSet() or InCombatLockdown() then return end
+
+        --- @type _Frame
+        local PDF = PaperDollFrame
+        C_EquipmentSet.UseEquipmentSet(w:GetEquipmentSetData().id)
+        PlaySound(SOUNDKIT.GUILD_BANK_OPEN_BAG)
+
+        local profile = w:GetProfileConfig()
+        if profile.equipmentset_open_character_frame then
+            if not PDF:IsVisible() then
+                ToggleCharacter('PaperDollFrame')
+                self:OpenEquipmentMgrConditionally(w, profile)
+            else self:OpenEquipmentMgrConditionally(w, profile) end
+        end
+    end
+
+    --- @private
+    function o:ConditionallyCheckButtons()
+        self:ForEachEquipmentSetButton(function(bw)
+            self:CheckIfEquipped(bw:EquipmentSetMixin())
+        end)
+    end
+    --- @private
+    --- @param esm EquipmentSetButtonMixin
+    function o:CheckIfEquipped(esm)
+        local equipped, set = esm:IsAllEquipped()
+        p:d(function()
+            return 'Is-Equipped::%s[%s]?: %s', esm.w:GN(), set.name ,tostring(equipped)
+        end)
+        esm.w:SetChecked(equipped)
+    end
+
+    --- @private
+    --- @param w ButtonUIWidget
+    --- @param profile Profile_Config
+    function o:OpenEquipmentMgrConditionally(w, profile)
+        if profile.equipmentset_open_equipment_manager == true then
+            --- @type _Frame
+            local gmDlg = GearManagerDialog
+            if gmDlg and gmDlg:IsVisible() then ClickEquipmentSetButtonDelayed(w) return end
+        end
+
+        --- Buttons:
+        --- • GearManagerToggleButton (pre-retail)
+        --- • PaperDollSidebarTab3 (retail)
+        --- @type _Button
+        local gmButton = GearManagerToggleButton or PaperDollSidebarTab3
+        if profile.equipmentset_open_equipment_manager ~= true then return end
+        C_Timer.After(0.1, function()
+            gmButton:Click()
+            self:ClickEquipmentSetButtonDelayed(w)
+        end)
+    end
+
+    --- @private
+    --- @param w ButtonUIWidget
+    function o:ClickEquipmentSetButtonDelayed(w)
+        C_Timer.After(0.2, function() self:ClickEquipmentSetButton(w) end)
+    end
+
+    --- @private
+    --- @param bw ButtonUIWidget
+    function o:ClickEquipmentSetButton(bw)
+        if bw:EquipmentSetMixin():IsMissingEquipmentSet() then return end
+
+        local equipmentSet = bw:GetEquipmentSetData()
+        local index = BaseAPI:GetEquipmentSetIndex(equipmentSet.id)
+
+        local btnName = 'GearSetButton' .. (index)
+        if _G[btnName] then _G[btnName]:Click() end
     end
 
     o:RegisterMessageCallbacks()

--- a/Core/Lib/Widget/EquipmentSetController.lua
+++ b/Core/Lib/Widget/EquipmentSetController.lua
@@ -1,0 +1,75 @@
+--- @alias EquipmentSetController __EquipmentSetController | ActionBarHandlerMixin
+--[[-----------------------------------------------------------------------------
+Local Vars
+-------------------------------------------------------------------------------]]
+--- @type Namespace
+local ns = select(2, ...)
+local O, GC, MSG, E = ns.O, ns.GC, ns.GC.M, ns.GC.E
+
+local AceBucket = ns:AceBucket()
+local toMsg = GC.toMsg
+local ES = O.EquipmentSetMixin
+local libName = 'EquipmentSetController'
+--[[-----------------------------------------------------------------------------
+New Instance
+-------------------------------------------------------------------------------]]
+--- @class __EquipmentSetController : BaseActionBarController
+local L = ns:NewActionBarHandler(libName);
+local p = ns:CreateDefaultLogger(libName)
+p:v(function() return "Loaded: %s", libName end)
+
+--[[-----------------------------------------------------------------------------
+Methods
+-------------------------------------------------------------------------------]]
+---@param o __EquipmentSetController | EquipmentSetController
+local function PropsAndMethods(o)
+
+    --- @private
+    function o:RegisterMessageCallbacks()
+        self:RegisterMessage(MSG.OnAddOnReady, function() self:OnAddOnReady()  end)
+        self:RegisterAddonMessage(E.EQUIPMENT_SETS_CHANGED, function(evt) self:OnEquipmentSetsChanged() end)
+        self:RegisterAddonMessage(E.EQUIPMENT_SWAP_FINISHED, function(evt, source, success, setID)
+            self:OnEquipmentSwapFinished(success, setID) end)
+    end
+
+    function o:OnAddOnReady()
+        p:f3('OnEquipmentSetsChanged called...')
+
+        self:ForEachEquipmentSetButton(function(bw)
+            local equipped, set = ES:New(bw):IsAllEquipped()
+            p:d(function() return 'Is-Equipped::%s[%s]?: %s',
+                bw:GN(), set.name ,tostring(equipped) end)
+            bw:SetChecked(equipped)
+        end)
+    end
+
+    --- @param frameWidget FrameWidget
+    --- @param event string
+    --- @private
+    function o:OnEquipmentSetsChanged(frameWidget, event)
+        p:f3('OnEquipmentSetsChanged called...')
+        self:ForEachEquipmentSetButton(function(bw)
+            ES:New(bw):UpdateEquipmentSet()
+        end)
+    end
+
+    --- @param success boolean
+    --- @param setID Identifier
+    function o:OnEquipmentSwapFinished(success, setID)
+        p:f3(function() return 'OnEquipmentSwapFinished called: equip-success=%s setID=%s',
+                tostring(success), tostring(setID) end)
+
+        self:ForEachEquipmentSetButton(function(bw)
+            local es = ES:New(bw)
+            es:RefreshTooltip(setID)
+            local d = bw:GetEquipmentSetData()
+            if d.id ~= setID then return bw:SetChecked(false) end
+
+            es:GlowButtonConditionally()
+            bw:SetChecked(true)
+        end)
+    end
+
+    o:RegisterMessageCallbacks()
+end; PropsAndMethods(L)
+

--- a/Core/Lib/Widget/EventToMessageRelayController.lua
+++ b/Core/Lib/Widget/EventToMessageRelayController.lua
@@ -51,7 +51,7 @@ function ns.H.EventToMessageRelayController_OnLoad(frame)
     --- @see GlobalConstants#M (Messages)
     RegisterFrameForEvents(frame, {
         E.PLAYER_ENTERING_WORLD,
-        E.EQUIPMENT_SETS_CHANGED, E.EQUIPMENT_SWAP_FINISHED,
+        E.EQUIPMENT_SETS_CHANGED, E.EQUIPMENT_SWAP_FINISHED, E.PLAYER_EQUIPMENT_CHANGED,
         E.PLAYER_MOUNT_DISPLAY_CHANGED, E.ZONE_CHANGED_NEW_AREA,
         E.BAG_UPDATE, E.BAG_UPDATE_DELAYED,
         E.MODIFIER_STATE_CHANGED,

--- a/Core/Lib/Widget/EventToMessageRelayController.lua
+++ b/Core/Lib/Widget/EventToMessageRelayController.lua
@@ -1,0 +1,65 @@
+--[[-----------------------------------------------------------------------------
+Local Vars
+-------------------------------------------------------------------------------]]
+--- @type Namespace
+local ns = select(2, ...)
+local O, GC, M, MSG, E = ns.O, ns.GC, ns.M, ns.GC.M, ns.GC.E
+local libName = ns.M.EventToMessageRelayController
+--[[-----------------------------------------------------------------------------
+New Instance
+-------------------------------------------------------------------------------]]
+--- @class EventToMessageRelayController : BaseLibraryObject_WithAceEvent
+local L = ns:NewLibXEvent(O.EventToMessageRelayController, libName)
+local p = ns:CreateDefaultLogger(libName)
+local pm = ns:LC().MESSAGE:NewLogger(libName)
+p:v(function() return "Loaded: %s", libName end)
+
+--[[-----------------------------------------------------------------------------
+Blizzard Vars
+-------------------------------------------------------------------------------]]
+local CreateFrame, FrameUtil = CreateFrame, FrameUtil
+local RegisterFrameForEvents, RegisterFrameForUnitEvents = FrameUtil.RegisterFrameForEvents, FrameUtil.RegisterFrameForUnitEvents
+
+--[[-----------------------------------------------------------------------------
+Methods
+-------------------------------------------------------------------------------]]
+---@param o EventToMessageRelayController
+local function PropsAndMethods(o)
+    local toMsg = GC.toMsg
+    function o:OnLoad(frame, event, ...)
+        p:vv('OnLoad called...')
+    end
+    function o:OnEvent(frame, event, ...)
+        p:vv('OnEvent called...')
+    end
+
+    --- @param event string
+    function o:OnMessageTransmitter(event, ...)
+        p:f1(function() return "Relaying event[%s] to [%s]", event, GC.toMsg(event) end)
+        self:SendMessage(toMsg(event), ns.name, ...)
+    end
+
+end; PropsAndMethods(L)
+
+--[[-----------------------------------------------------------------------------
+Frame Event Handlers: ABP_EventToMessageRelayControllerFrame
+-------------------------------------------------------------------------------]]
+---@param frame _Frame
+function ns.H.EventToMessageRelayController_OnLoad(frame)
+    frame:SetScript(E.OnEvent, function(self, evt, ...) L:OnMessageTransmitter(evt, ...) end)
+
+    --- @see GlobalConstants#M (Messages)
+    RegisterFrameForEvents(frame, {
+        E.PLAYER_ENTERING_WORLD,
+        E.EQUIPMENT_SETS_CHANGED, E.EQUIPMENT_SWAP_FINISHED,
+        E.PLAYER_MOUNT_DISPLAY_CHANGED, E.ZONE_CHANGED_NEW_AREA,
+        E.BAG_UPDATE, E.BAG_UPDATE_DELAYED,
+        E.MODIFIER_STATE_CHANGED,
+        E.CVAR_UPDATE,
+    })
+end
+
+---@param frame _Frame
+function ns.H.EventToMessageRelayController_OnEvent(frame)
+
+end

--- a/Core/Lib/Widget/_Widget.xml
+++ b/Core/Lib/Widget/_Widget.xml
@@ -8,6 +8,7 @@
     <Script file="MacroEventsHandler.lua"/>
     <Script file="ActionbarPlusEventMixin.lua"/>
 
+    <Include file="ConfigDialogController.lua"/>
     <Include file="ActionBarController.xml"/>
 
 </Ui>

--- a/Core/_ExtLib_WowAce_Ace3.xml
+++ b/Core/_ExtLib_WowAce_Ace3.xml
@@ -17,6 +17,4 @@
     <Include file="ExtLib\WowAce\Ace3\AceTab-3.0\AceTab-3.0.xml"/>
     <Include file="ExtLib\WowAce\Ace3\AceSerializer-3.0\AceSerializer-3.0.xml"/>
 
-    <Include file="ExtLib\WowAce\LibSharedMedia\LibSharedMedia-3.0\lib.xml"/>
-
 </Ui>

--- a/dev/pkgmeta-dev.yaml
+++ b/dev/pkgmeta-dev.yaml
@@ -54,7 +54,10 @@ ignore:
   - Core/_Core.lua
   - Core/_Core.xml
   - Core/_ExtLib.xml
-  - Core/_ExtLib_WowAce.xml
+  - Core/_ExtLib_WowAce_Ace3.xml
+  - Core/_ExtLib_WowAce_Misc.xml
+  - Core/ActionbarPlus.lua
+  - Core/ActionbarPlusAPI.lua
   - Core/AddonLib
   - Core/Assets
   - Core/Global


### PR DESCRIPTION
### Main
- Resolves #371: Hide Settings Dialog when a combat lockdown is trigger
- Resolves #329: Active State for Equipmentsets
### Misc
- Created a main event-to-message relay EventToMessageRelayController.lua
- Migrated Equipment events from ButtonFrameFactory.lua to EquipmentSetController; Created EquipmentSetMixin for equipment set logic
- Added ButtonUI.CheckedTexture for EquipmentSet "active" state
- Bag Events moved to BagController
- Use generic onload message GC:GetMessageLoadedText()
- Update to kapresoft lib CategoryMixin:New()
- Added ns.H / ABP_H for event handlers in XML (see ActionBarController.xml)
- Added new LogCategory TRACE for generic tracing