### PR TITLE
Fix #447 Use 'item:<itemId>' for setting the item attribute.

### DIFF
--- a/Core/Lib/Widget/Buttons/ItemDragEventHandler.lua
+++ b/Core/Lib/Widget/Buttons/ItemDragEventHandler.lua
@@ -102,7 +102,7 @@ local function attributeSetterMethods(a)
 
         btnUI.widget:SetIcon(itemData.icon)
         btnUI:SetAttribute(WAttr.TYPE, WAttr.ITEM)
-        btnUI:SetAttribute(WAttr.ITEM, itemData.name)
+        btnUI:SetAttribute(WAttr.ITEM, 'item:' .. itemData.id)
 
         self:OnAfterSetAttributes(btnUI)
     end


### PR DESCRIPTION
Fixes #447

Use 'item:<itemId>' for setting the item attribute.