### PR TITLE
Fix GitHub URLs in TOC files

### DIFF
--- a/ActionbarPlus-Cata.toc
+++ b/ActionbarPlus-Cata.toc
@@ -13,8 +13,8 @@
 ## X-Category: ActionBars
 ## X-License: All Rights Reserved. |cff1784d1This addon is provided 'as is' without any warranties. All rights reserved. Redistribution or modification is not permitted.|r
 
-## X-Github-Repo: https://github.com/kapresoft/wowaddon-actionbar-plus
-## X-Github-Issues: https://github.com/kapresoft/wowaddon-actionbar-plus/issues
+## X-Github-Repo: https://github.com/kapresoft/wow-addon-actionbar-plus
+## X-Github-Issues: https://github.com/kapresoft/wow-addon-actionbar-plus/issues
 ## X-CurseForge: https://www.curseforge.com/wow/addons/actionbarplus
 ## X-Curse-Project-ID: 566626
 ## X-Github-Project-Author: @project-author@

--- a/ActionbarPlus-Mists.toc
+++ b/ActionbarPlus-Mists.toc
@@ -13,8 +13,8 @@
 ## X-Category: Action Bars
 ## X-License: All Rights Reserved. |cff1784d1This addon is provided 'as is' without any warranties. All rights reserved. Redistribution or modification is not permitted.|r
 
-## X-Github-Repo: https://github.com/kapresoft/wowaddon-actionbar-plus
-## X-Github-Issues: https://github.com/kapresoft/wowaddon-actionbar-plus/issues
+## X-Github-Repo: https://github.com/kapresoft/wow-addon-actionbar-plus
+## X-Github-Issues: https://github.com/kapresoft/wow-addon-actionbar-plus/issues
 ## X-CurseForge: https://www.curseforge.com/wow/addons/actionbarplus
 ## X-Curse-Project-ID: 566626
 ## X-Github-Project-Author: @project-author@

--- a/ActionbarPlus-Vanilla.toc
+++ b/ActionbarPlus-Vanilla.toc
@@ -13,8 +13,8 @@
 ## X-Category: Action Bars
 ## X-License: All Rights Reserved. |cff1784d1This addon is provided 'as is' without any warranties. All rights reserved. Redistribution or modification is not permitted.|r
 
-## X-Github-Repo: https://github.com/kapresoft/wowaddon-actionbar-plus
-## X-Github-Issues: https://github.com/kapresoft/wowaddon-actionbar-plus/issues
+## X-Github-Repo: https://github.com/kapresoft/wow-addon-actionbar-plus
+## X-Github-Issues: https://github.com/kapresoft/wow-addon-actionbar-plus/issues
 ## X-CurseForge: https://www.curseforge.com/wow/addons/actionbarplus
 ## X-Curse-Project-ID: 566626
 ## X-Github-Project-Author: @project-author@

--- a/ActionbarPlus-Wrath.toc
+++ b/ActionbarPlus-Wrath.toc
@@ -13,8 +13,8 @@
 ## X-Category: Action Bars
 ## X-License: All Rights Reserved. |cff1784d1This addon is provided 'as is' without any warranties. All rights reserved. Redistribution or modification is not permitted.|r
 
-## X-Github-Repo: https://github.com/kapresoft/wowaddon-actionbar-plus
-## X-Github-Issues: https://github.com/kapresoft/wowaddon-actionbar-plus/issues
+## X-Github-Repo: https://github.com/kapresoft/wow-addon-actionbar-plus
+## X-Github-Issues: https://github.com/kapresoft/wow-addon-actionbar-plus/issues
 ## X-CurseForge: https://www.curseforge.com/wow/addons/actionbarplus
 ## X-Curse-Project-ID: 566626
 ## X-Github-Project-Author: @project-author@

--- a/ActionbarPlus.toc
+++ b/ActionbarPlus.toc
@@ -14,8 +14,8 @@
 ## X-Category: Action Bars
 ## X-License: All Rights Reserved. |cff1784d1This addon is provided 'as is' without any warranties. All rights reserved. Redistribution or modification is not permitted.|r
 
-## X-Github-Repo: https://github.com/kapresoft/wowaddon-actionbar-plus
-## X-Github-Issues: https://github.com/kapresoft/wowaddon-actionbar-plus/issues
+## X-Github-Repo: https://github.com/kapresoft/wow-addon-actionbar-plus
+## X-Github-Issues: https://github.com/kapresoft/wow-addon-actionbar-plus/issues
 ## X-CurseForge: https://www.curseforge.com/wow/addons/actionbarplus
 ## X-Curse-Project-ID: 566626
 ## X-Github-Project-Author: @project-author@


### PR DESCRIPTION
## Summary
- correct repository links in AddOn TOC metadata

## Testing
- `grep -n "wow-addon-actionbar-plus" -R *.toc`


------
https://chatgpt.com/codex/tasks/task_e_683f6454b3c4832b827515ab7f433d3c