### PR TITLE
Improve spell rank lookup caching

### DIFF
--- a/Core/Lib/Widget/Buttons/SpellDragEventHandler.lua
+++ b/Core/Lib/Widget/Buttons/SpellDragEventHandler.lua
@@ -11,6 +11,9 @@ local IsNotBlank, IsBlank = String.IsNotBlank, String.IsBlank
 local BAttr, WAttr, UAttr = GC.ButtonAttributes,  GC.WidgetAttributes, GC.UnitIDAttributes
 local Compat, Dru = O.Compat, O.DruidUnitMixin
 
+-- Cache table for spell ranks
+local highestSpellRankCache = {}
+
 --[[-----------------------------------------------------------------------------
 New Instance: SpellDragEventHandler
 -------------------------------------------------------------------------------]]
@@ -141,15 +144,27 @@ local function attributeSetterMethods(a)
 
     function a:GetHighestSpellRank(spellName)
         if not GetSpellBookItemName then return nil end
+        if IsBlank(spellName) then return nil end
+
+        -- Check cache first
+        local rank = highestSpellRankCache[spellName]
+        if rank ~= nil then return rank end
+
         local i = 1
         local lastRank
         while true do
-            local name, rank = GetSpellBookItemName(i, BOOKTYPE_SPELL)
+            local name, r = GetSpellBookItemName(i, BOOKTYPE_SPELL)
             if not name then break end
-            if rank and name == spellName then lastRank = rank end
+            if r and name == spellName then lastRank = r end
             i = i + 1
         end
+
+        highestSpellRankCache[spellName] = lastRank
         return lastRank
+    end
+
+    function a:ClearSpellRankCache()
+        highestSpellRankCache = {}
     end
 
 end


### PR DESCRIPTION
## Summary
- cache highest spell rank lookups in `SpellDragEventHandler`
- add cache clear method for talent or world changes

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_685b918e9d34832b8e7649a03c9a20db