### PR TITLE
Fix quoting for changelog output

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -133,8 +133,8 @@ jobs:
           export c_RESOLVED_VERSION="${{ env.refName }}"
           c_changeLog="$(envsubst < ${GITHUB_WORKSPACE}/.github/changelog-custom.md)"
           CHANGELOG_FILE="${GITHUB_WORKSPACE}/CHANGELOG.txt"
-          echo -e "${c_changeLog}" | tee ${CHANGELOG_FILE}
-          echo '${{ steps.build_changelog.outputs.changelog }}' | tee -a ${CHANGELOG_FILE}
+          printf '%s\n' "${c_changeLog}" | tee "${CHANGELOG_FILE}"
+          printf '%s\n' "${{ steps.build_changelog.outputs.changelog }}" | tee -a "${CHANGELOG_FILE}"
       ## ------------------------------------------------ ##
       ## see: https://github.com/marketplace/actions/wow-packager
       - uses: BigWigsMods/packager@v2


### PR DESCRIPTION
## Summary
- handle special characters when generating `CHANGELOG.txt`
- Fixes #471 
## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d582a4e60832b9c41e231c25e62ee