### PR TITLE
Fix quoting for changelog output

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -134,7 +134,9 @@ jobs:
           c_changeLog="$(envsubst < ${GITHUB_WORKSPACE}/.github/changelog-custom.md)"
           CHANGELOG_FILE="${GITHUB_WORKSPACE}/CHANGELOG.txt"
           printf '%s\n' "${c_changeLog}" | tee "${CHANGELOG_FILE}"
-          printf '%s\n' "${{ steps.build_changelog.outputs.changelog }}" | tee -a "${CHANGELOG_FILE}"
+          cat <<'CHANGELOG' | tee -a "${CHANGELOG_FILE}"
+${{ steps.build_changelog.outputs.changelog }}
+CHANGELOG
       ## ------------------------------------------------ ##
       ## see: https://github.com/marketplace/actions/wow-packager
       - uses: BigWigsMods/packager@v2


### PR DESCRIPTION
## Summary
- handle multi-line special characters when generating `CHANGELOG.txt`
- Second attempt to fix #470


------
https://chatgpt.com/codex/tasks/task_e_686d582a4e60832b9c41e231c25e62ee