### PR TITLE
v2

### DIFF
--- a/ActionbarPlus-BarsUI/ActionbarPlus-BarsUI-Mists.toc
+++ b/ActionbarPlus-BarsUI/ActionbarPlus-BarsUI-Mists.toc
@@ -1,4 +1,4 @@
-## Interface: 20505
+## Interface: 50503
 ## Version: @project-version@
 ## Title: |TInterface/AddOns/ActionbarPlus-Core/Assets/Textures/logo-v2-64x:18:18|tActionbar|cff1784d1Plus|r|cffffffff-BarsUI|r
 

--- a/ActionbarPlus-BarsUI/Modules/ButtonTemplate.xml
+++ b/ActionbarPlus-BarsUI/Modules/ButtonTemplate.xml
@@ -85,8 +85,14 @@
                         -- others: FACTION_GREEN_COLOR, RED_THREAT_COLOR, YELLOW_THREAT_COLOR
                         local c = RED_THREAT_COLOR
                         tex:SetVertexColor(c.r, c.g, c.b, c.a)
-                        tex:Show();
+                        tex:Show()
                     </OnPlay>
+                    <OnStop>
+                        local btn = self:GetParent()
+                        local tex = btn and btn.SpellHighlightTexture; if not tex then return end
+                        tex:Hide()
+                        tex:SetVertexColor(1, 1, 1, 1)
+                    </OnStop>
                 </Scripts>
             </AnimationGroup>
         </Animations>

--- a/ActionbarPlus-BarsUI/Modules/ButtonTemplate.xml
+++ b/ActionbarPlus-BarsUI/Modules/ButtonTemplate.xml
@@ -33,7 +33,7 @@
                 </FontString>
                 <FontString name="$parentCount" inherits="NumberFontNormal" parentKey="Count" justifyH="RIGHT">
                     <Anchors>
-                        <Anchor point="BOTTOMRIGHT" x="-2" y="2"/>
+                        <Anchor point="BOTTOMRIGHT" x="-5" y="5"/>
                     </Anchors>
                 </FontString>
             </Layer>

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3.lua
@@ -143,6 +143,8 @@ function o:OnEvent(evt, ...)
     self:UpdateUsable()
   elseif evt == 'SPELL_UPDATE_USABLE' then
     self:UpdateUsable()
+  elseif evt == 'SPELL_UPDATE_CHARGES' then
+    self:UpdateCount()
   elseif evt == 'PLAYER_LEAVE_COMBAT' then
     -- note: PLAYER_LEAVE_COMBAT gets fired when the player stops
     -- attacking (even when player is in combat)
@@ -180,6 +182,12 @@ function o:OnEvent(evt, ...)
     self:UpdateState('OnEvent')
   --elseif evt == 'UNIT_AURA' then
   --  self:UpdateStealthSpells()
+  elseif evt == 'SPELL_ACTIVATION_OVERLAY_GLOW_SHOW' then
+    local spellID = ...
+    if self:MatchesSpellID(spellID) then self.widget:ShowOverlayGlow() end
+  elseif evt == 'SPELL_ACTIVATION_OVERLAY_GLOW_HIDE' then
+    local spellID = ...
+    if self:MatchesSpellID(spellID) then self.widget:HideOverlayGlow() end
   elseif evt == 'BAG_UPDATE_COOLDOWN' then
     --t('OnEvent', 'evt=', evt)
     self:UpdateCooldown()
@@ -515,4 +523,4 @@ function o:Any() self:RegisterForClicks('AnyDown', 'AnyUp') end
 function o:SetButtonStateNormal() self:SetButtonState('NORMAL') end
 function o:SetButtonStatePushed() self:SetButtonState('PUSHED') end
 function o:SetButtonStateDisabled() self:SetButtonState('DISABLED') end
-
+function o:MatchesSpellID(spellID) return self.widget:MatchesSpellID(spellID) end

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3.lua
@@ -143,12 +143,25 @@ function o:OnEvent(evt, ...)
   elseif evt == 'SPELL_UPDATE_USABLE' then
     self:UpdateUsable()
   elseif evt == 'PLAYER_LEAVE_COMBAT' then
+    -- note: PLAYER_LEAVE_COMBAT gets fired when the player stops
+    -- attacking (even when player is in combat)
     self:UpdateState(evt)
-    self:DisableAttackingAnimation()
-  elseif evt == 'PLAYER_TARGET_SET_ATTACKING' then
-    if o.Btn_ActionRequiresAttackAnim(self) then
+    self:DisableFlashAnimation()
+  elseif evt == 'START_AUTOREPEAT_SPELL' then
+    --t('START_AUTOREPEAT_SPELL', 'attributeSpell=', self.widget:GetAttributeSpell())
+    if self.widget:RequiresShootAnimation() then
       self:SetChecked(true)
-      self:EnableAttackingAnimation()
+      self:EnableFlashAnimation()
+    end
+  elseif evt == 'STOP_AUTOREPEAT_SPELL' then
+    if self.widget:IsShootSpell() then
+      self:SetChecked(false)
+      self:DisableFlashAnimation()
+    end
+  elseif evt == 'PLAYER_TARGET_SET_ATTACKING' then
+    if self.widget:RequiresAttackAnimation() then
+      self:SetChecked(true)
+      self:EnableFlashAnimation()
       return
     end
     self:UpdateState(evt)
@@ -187,6 +200,7 @@ end
 function o:OnPlayerMatchingSpellcastEvent(evt, spellID)
   -- todo: in classic-era, older rank spells are non castable
   local sp = comp:GetSpellName(spellID)
+ --t('OnPlayerMatchingSpellcastEvent', 'evt=', evt, 'spellID=', spellID, sp)
   if evt == 'UNIT_SPELLCAST_SENT' then
       self:SetChecked(true)
   elseif evt == 'UNIT_SPELLCAST_START' then
@@ -247,7 +261,7 @@ function o:PreClickAction(button, down)
   -- When the user begins dragging the button, the secure `type` attribute
   -- must be temporarily suspended so the button does not execute its
   -- action while the drag / pickup transaction is in progress.
-  if o.Btn_ActionShouldFire(self, down) and self:IsDragAllowed() then
+  if o.Btn_ActionShouldFire(self, down) and self.widget:IsDragAllowed() then
     self:SetChecked(false)
     self.widget:SuspendAction()
     return
@@ -326,7 +340,7 @@ function o:OnLeave() GameTooltip:Hide() end
 --- @param button ButtonName
 function o:OnDragStart(button)
   if InCombatLockdown() then return false end
-  if not self:IsDragAllowed() then return end
+  if not self.widget:IsDragAllowed() then return end
 
   o.Btn_PickupAction(self, function()
     self:UpdateState('OnDragStart')
@@ -407,10 +421,6 @@ function o:Update()
   self.__updating = false
 end
 
---- @see ButtonHandlerMixin_ABP_2_0.Btn_GetActionTexture
---- @return TextureIcon?
-function o:GetActionTexture() return o.Btn_GetActionTexture(self) end
-
 --[[-------------------------------------------------------------------
 Convenience Methods
 ---------------------------------------------------------------------]]
@@ -466,33 +476,9 @@ function o:UpdateCooldown()
   cd:Clear()
 end
 
---- Returns info for a known spell.  An unknown spell will return nil values.
+--- @see ButtonWidget_ABP_2_0.GetActionInfo()
 --- @return string?, ActionID? @The type (e.g. spell, item) and resolved typeID (spellID/itemID)
-function o:GetActionInfo()
-  local actionType = self:GetAttribute(attr.type)
-  if not actionType then return nil, nil end
-  
-  --- @type ActionID
-  local val = self:GetAttribute(actionType)
-  if not val then return nil, nil end
-  
-  if type(val) == "number" then return actionType, val end
-
-  if type(val) == "string" then
-    if au.IsSpell(actionType) then
-      local sp = comp:GetSpellInfo(val)
-      if not sp then return nil, nil end
-      return actionType, sp.spellID
-    elseif au.IsItem(actionType) then
-      local itemID = self.widget:GetAttributeItemID()
-      return actionType, itemID
-    elseif au.IsMacro(actionType) then
-      error(self:GetName() .. ':: GetActionInfo(): macro support not implemented')
-    end
-  end
-  
-  return nil, nil
-end
+function o:GetActionInfo() return self.widget:GetActionInfo() end
 
 --- @return string|nil, number|nil The suspended action type (e.g. spell, item) and the suspended action type value (spellID/itemID). If one is nil, both are nil.
 function o:GetSuspendedActionInfo()
@@ -510,42 +496,23 @@ end
 function o:SetIconVertex(r, g, b) self.icon:SetVertexColor(r, g, b) end
 function o:SetIconNormalVertex() self:SetIconVertex(1, 1, 1) end
 function o:DimIcon() self:SetIconVertex(0.5, 0.5, 0.5) end
-
----@param callbackFn fun(icon:Icon):void
-function o:IfActionTexture(callbackFn)
-  local icon = self:GetActionTexture()
-  if not icon then return end
-  callbackFn(icon)
-end
-
 function o:UpdateState(evt) o.Btn_UpdateState(self, evt) end
 function o:UpdateAnimation() o.Btn_UpdateAnimation(self) end
 function o:UpdateFlash() o.Btn_UpdateFlash(self) end
+
 function o:ClearFlash()
   -- tbd
 end
 
 function o:UpdateTexture()
-  self:IfActionTexture(function(icon) self.icon:SetTexture(icon) end)
+  self.widget:IfActionTexture(function(icon) self.icon:SetTexture(icon) end)
 end
 
-function o:IsDragAllowed()
-  return not Settings.GetValue('lockActionBars') or IsModifiedClick('PICKUPACTION')
-end
-
+function o:EnableFlashAnimation() self.widget:EnableFlashAnimation() end
+function o:DisableFlashAnimation() self.widget:DisableFlashAnimation() end
 function o:AnyDown() self:RegisterForClicks('AnyDown') end
 function o:Any() self:RegisterForClicks('AnyDown', 'AnyUp') end
 function o:SetButtonStateNormal() self:SetButtonState('NORMAL') end
 function o:SetButtonStatePushed() self:SetButtonState('PUSHED') end
 function o:SetButtonStateDisabled() self:SetButtonState('DISABLED') end
 
-function o:EnableAttackingAnimation()
-  if self.SpellHighlightAnim:IsPlaying() then return end
-  self.SpellHighlightAnim:Play()
-end
-
-function o:DisableAttackingAnimation()
-  if not self.SpellHighlightAnim:IsPlaying() then return end
-  self.SpellHighlightAnim:Stop()
-  self.SpellHighlightTexture:Hide()
-end

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3.lua
@@ -45,12 +45,13 @@ New Instance
 local libName = 'Button_2_0_3'
 
 --- @class ButtonMixin_ABP_2_0_3 : ButtonHandlerMixin_ABP_2_0, ButtonConfigAccessor_ABP_2_0, SecureActionButtonTemplate, CheckButton, AceEvent-3.0
---- @field NormalTexture TextureObj
---- @field HighlightTexture TextureObj
---- @field PushedTexture TextureObj
---- @field CheckedTexture TextureObj
+--- @field NormalTexture Texture
+--- @field HighlightTexture Texture
+--- @field PushedTexture Texture
+--- @field CheckedTexture Texture
 --- @field SpellHighlightAnim AnimationGroup
---- @field icon TextureObj
+--- @field Count FontString
+--- @field icon Texture
 --- @field cooldown CooldownObj
 --- @field eventsRegistered boolean
 --- @field widget ButtonWidget_ABP_2_0
@@ -185,6 +186,7 @@ function o:OnEvent(evt, ...)
     self:UpdateUsable()
   elseif evt == 'BAG_UPDATE_DELAYED' then
     self:UpdateUsable()
+    self:UpdateCount()
   end
   
 end
@@ -405,6 +407,7 @@ function o:Update()
     --ActionButton_UpdateCooldown(self)
     self:UpdateCooldown()
     self:UpdateFlash()
+    self:UpdateCount()
     --self:UpdateHighlightMark()
     --self:UpdateSpellHighlightMark()
   else
@@ -499,10 +502,7 @@ function o:DimIcon() self:SetIconVertex(0.5, 0.5, 0.5) end
 function o:UpdateState(evt) o.Btn_UpdateState(self, evt) end
 function o:UpdateAnimation() o.Btn_UpdateAnimation(self) end
 function o:UpdateFlash() o.Btn_UpdateFlash(self) end
-
-function o:ClearFlash()
-  -- tbd
-end
+function o:UpdateCount() self.widget:UpdateCount() end
 
 function o:UpdateTexture()
   self.widget:IfActionTexture(function(icon) self.icon:SetTexture(icon) end)

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3.lua
@@ -317,7 +317,6 @@ function o:PostClickAction(button, down)
       --  todo: handle macro
     end
   end
-
   self.widget:ClearAttributeSuspendedActionType()
   self.widget:SetActionFromCursor(cursor)
 end

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ActionEventsFrameMixin.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ActionEventsFrameMixin.lua
@@ -21,7 +21,7 @@ Behavior:
 - Maintains a registry of button frames (self.frames).
 - For spellcast-related events:
   - Extracts spellID.
-  - Calls frame:MatchesActiveButtonSpellID(spellID).
+  - Calls frame:MatchesSpellID(spellID).
   - Dispatches only to matching buttons.
 - For non-spellcast action events:
   - Broadcasts as needed.
@@ -128,23 +128,23 @@ end
 ---@param ... any
 function o:OnEvent(evt, ...)
   if ( evt == "UNIT_INVENTORY_CHANGED" ) then
-    local unit = ...;
-    if ( unit == "player" and self.tooltipOwner and GameTooltip:GetOwner() == self.tooltipOwner ) then
+    local unitName = ...;
+    if ( unitName == "player" and self.tooltipOwner and GameTooltip:GetOwner() == self.tooltipOwner ) then
       self.tooltipOwner:SetTooltip();
     end
   elseif ( self:IsSpellcastEvent(evt) ) then
     ---@param btn Button_ABP_2_0_3
     for k, btn in pairs(self.frames) do
       local spellID;
-      local unit = ...;
+      local unitName = ...;
       
       if(evt == "UNIT_SPELLCAST_SENT") then
         spellID = select(4, ...)
       else
         spellID = select(3, ...)
       end
-      
-      if (unit == "player" and btn.widget:MatchesActiveButtonSpellID(spellID)) then
+
+      if (unitName == "player" and btn:MatchesSpellID(spellID)) then
         btn:OnPlayerMatchingSpellcastEvent(evt, spellID);
       end
     end

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ActionEventsFrameMixin.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ActionEventsFrameMixin.lua
@@ -35,8 +35,8 @@ This frame performs no state logic itself; it only routes events.
 ---------------------------------------------------------------------]]
 --- @type Namespace_ABP_BarsUI_2_0
 local ns = select(2, ...)
-local cns = ns:cns()
-local comp = cns.O.Compat
+local cns, O = ns:cns()
+local comp, unit = O.Compat, O.UnitUtil
 local p, t = ns:log('ActionEventsFrame')
 
 --[[-------------------------------------------------------------------
@@ -127,9 +127,9 @@ end
 ---@param evt EventName
 ---@param ... any
 function o:OnEvent(evt, ...)
-  if ( evt == "UNIT_INVENTORY_CHANGED" ) then
+  if ( evt == 'UNIT_INVENTORY_CHANGED' ) then
     local unitName = ...;
-    if ( unitName == "player" and self.tooltipOwner and GameTooltip:GetOwner() == self.tooltipOwner ) then
+    if ( unit:IsPlayer(unitName) and self.tooltipOwner and GameTooltip:GetOwner() == self.tooltipOwner ) then
       self.tooltipOwner:SetTooltip();
     end
   elseif ( self:IsSpellcastEvent(evt) ) then
@@ -137,14 +137,13 @@ function o:OnEvent(evt, ...)
     for k, btn in pairs(self.frames) do
       local spellID;
       local unitName = ...;
-      
-      if(evt == "UNIT_SPELLCAST_SENT") then
+
+      if(evt == 'UNIT_SPELLCAST_SENT') then
         spellID = select(4, ...)
       else
         spellID = select(3, ...)
       end
-
-      if (unitName == "player" and btn:MatchesSpellID(spellID)) then
+      if (unit:IsPlayer(unitName) and btn:MatchesSpellID(spellID)) then
         btn:OnPlayerMatchingSpellcastEvent(evt, spellID);
       end
     end

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonHandlerMixin.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonHandlerMixin.lua
@@ -35,60 +35,6 @@ function o.Btn_ActionShouldFire(self, down)
 end
 
 --- @param self Button_ABP_2_0_X
---- @return boolean
-function o.Btn_ActionRequiresAttackAnim(self)
-    local typeVal, id = self:GetActionInfo()
-    if not (typeVal and id) then return false end
-    if au.IsSpell(typeVal)  then
-      return au.SpellRequiresAttackAnim(id)
-    end
-    return false
-end
-
---- @param self Button_ABP_2_0_X
---- @return TextureIcon?
-function o.Btn_GetActionTexture(self)
-  local typeVal, id = self:GetActionInfo()
-  if not id then return nil end
-  if au.IsMount(typeVal) then return end
-
-  local iconID
-  if au.IsSpell(typeVal) then
-    if unit:CanShapeShift() then
-      local formOrStealthActive = false
-      -- some shapeshifts have
-      -- different icons when active
-      if unit:IsStealthActive()
-          and (druid:IsProwl(id) or rogue:IsStealth(id)) then
-        -- Druid and Rogue use the same stealth icon
-        formOrStealthActive = true
-        iconID = unit:GetStealthedIcon()
-      elseif priest:IsShadowFormSpell(id) and priest:IsShapeShifted() then
-        formOrStealthActive = true
-        iconID = priest:GetShadowFormActiveIcon()
-      elseif shammy:IsGhostWolfSpell(id) and shammy:IsInGhostWolfForm() then
-        iconID = shammy:GetFormActiveIcon()
-      end
-      if formOrStealthActive then
-        self:DimIcon()
-      else
-        self:SetIconNormalVertex()
-      end
-    end
-    if not iconID then
-      local info = comp:GetSpellInfo(id)
-      if info and info.iconID then iconID = info.iconID end
-    end
-  elseif au.IsItem(typeVal) then
-    au.IfItem(self.widget:GetAttributeItemID(), function(itemInfo)
-        iconID = itemInfo.icon
-    end)
-  end
-  return iconID
-end
-
-
---- @param self Button_ABP_2_0_X
 --- @param callbackFn fun() : void
 function o.Btn_PickupAction(self, callbackFn)
   --- The abp_saved_type is saved during PreClick()
@@ -134,11 +80,11 @@ function o.Btn_UpdateAnimation(self)
   if not btnC then return end
 
   if au.IsSpell(btnC.type) then
-    local requiresAttackAnim = au.SpellRequiresAttackAnim(btnC.id)
-    if requiresAttackAnim and au.IsCurrentSpell(btnC.id) then
-      self:EnableAttackingAnimation()
+
+    if au.IsAutoAttackInProgress(btnC.id) then
+      self:EnableFlashAnimation()
     else
-      self:DisableAttackingAnimation()
+      self:DisableFlashAnimation()
     end
   end
 end

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonWidgetMixin.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonWidgetMixin.lua
@@ -4,7 +4,9 @@ Local Vars
 --- @type Namespace_ABP_BarsUI_2_0
 local ns = select(2, ...)
 local cns, O = ns:cns()
-local comp, au, unit, shaman = O.Compat, O.ActionUtil, O.UnitUtil, O.ShamanUtil
+local comp, au, unit = O.Compat, O.ActionUtil, O.UnitUtil
+local druid, rogue, shammy, priest =
+      O.DruidUtil, O.RogueUtil, O.ShamanUtil, O.PriestUtil
 local attr, atyp = cns:constants()
 local Str_IsBlank = cns:String().IsBlank
 
@@ -172,7 +174,7 @@ function o:__ResetVisuals()
   -- Stop flashing if you use it
   if btn.ClearFlash then btn:ClearFlash() end
 
-  btn:DisableAttackingAnimation()
+  btn.widget:DisableFlashAnimation()
 
   -- Remove any desaturation
   if btn.icon then btn.icon:SetDesaturated(false) end
@@ -192,6 +194,83 @@ function o:__ClearActionAttributes()
   for _, typeAttribute in ipairs(atyp) do
     self:SetAttribute(typeAttribute, nil)
   end
+end
+
+--- Returns info for a known spell.  An unknown spell will return nil values.
+--- @return string?, ActionID? @The type (e.g. spell, item) and resolved typeID (spellID/itemID)
+function o:GetActionInfo()
+  local actionType = self:GetAttribute(attr.type)
+  if not actionType then return nil, nil end
+
+  --- @type ActionID
+  local val = self:GetAttribute(actionType)
+  if not val then return nil, nil end
+
+  if type(val) == "number" then return actionType, val end
+
+  if type(val) == "string" then
+    if au.IsSpell(actionType) then
+      local sp = comp:GetSpellInfo(val)
+      if not sp then return nil, nil end
+      return actionType, sp.spellID
+    elseif au.IsItem(actionType) then
+      local itemID = self:GetAttributeItemID()
+      return actionType, itemID
+    elseif au.IsMacro(actionType) then
+      error(self.button:GetName() .. ':: GetActionInfo(): macro support not implemented')
+    end
+  end
+
+  return nil, nil
+end
+
+--- @return TextureIcon?
+function o:GetActionTexture()
+  local btn = self.button
+  local typeVal, id = self:GetActionInfo()
+  if not id then return nil end
+  if au.IsMount(typeVal) then return end
+
+  local iconID
+  if au.IsSpell(typeVal) then
+    if unit:CanShapeShift() then
+      local formOrStealthActive = false
+      -- some shapeshifts have
+      -- different icons when active
+      if unit:IsStealthActive()
+          and (druid:IsProwl(id) or rogue:IsStealth(id)) then
+        -- Druid and Rogue use the same stealth icon
+        formOrStealthActive = true
+        iconID = unit:GetStealthedIcon()
+      elseif priest:IsShadowFormSpell(id) and priest:IsShapeShifted() then
+        formOrStealthActive = true
+        iconID = priest:GetShadowFormActiveIcon()
+      elseif shammy:IsGhostWolfSpell(id) and shammy:IsInGhostWolfForm() then
+        iconID = shammy:GetFormActiveIcon()
+      end
+      if formOrStealthActive then
+        btn:DimIcon()
+      else
+        btn:SetIconNormalVertex()
+      end
+    end
+    if not iconID then
+      local info = comp:GetSpellInfo(id)
+      if info and info.iconID then iconID = info.iconID end
+    end
+  elseif au.IsItem(typeVal) then
+    au.IfItem(self:GetAttributeItemID(), function(itemInfo)
+        iconID = itemInfo.icon
+    end)
+  end
+  return iconID
+end
+
+--- @param callbackFn fun(icon:Icon):void
+function o:IfActionTexture(callbackFn)
+  local icon = self:GetActionTexture()
+  if not icon then return end
+  callbackFn(icon)
 end
 
 function o:ClearAttributeType() self:SetAttribute(attr.type, nil) end
@@ -267,6 +346,17 @@ function o:SetActionItem(itemID)
   self.itemSpellID = comp:GetItemSpell(itemID)
 end
 
+--- @return boolean
+function o:IsDragAllowed()
+  return not Settings.GetValue('lockActionBars')
+                or IsModifiedClick('PICKUPACTION')
+end
+
+function o:IsAutoAttacking()
+  local typeVal, id = self:GetActionInfo()
+  return au.IsAutoAttackInProgress(id)
+end
+
 --[[-------------------------------------------------------------------
 Delegate Functions
 ---------------------------------------------------------------------]]
@@ -282,3 +372,33 @@ function o:GetAttribute(attributeName) return self.button:GetAttribute(attribute
 --- @param attributeName string
 --- @param value any
 function o:SetAttribute(attributeName, value) self.button:SetAttribute(attributeName, value) end
+
+--- @return boolean
+function o:IsShootSpell()
+  local typeVal, id = self:GetActionInfo()
+  if not (typeVal and id) then return false end
+  return au.IsSpell(typeVal) and au.IsShootSpell(id)
+end
+
+--- @return boolean
+function o:RequiresShootAnimation()
+  local typeVal, id = self:GetActionInfo()
+  if not (typeVal and id) then return false end
+  return au.IsSpell(typeVal) and au.IsShootingInProgress(id)
+end
+
+--- @return boolean
+function o:RequiresAttackAnimation()
+  local typeVal, id = self:GetActionInfo()
+  if not (typeVal and id) then return false end
+  return au.IsSpell(typeVal) and au.IsAutoAttackInProgress(id)
+end
+
+function o:EnableFlashAnimation()
+  C_Timer.After(0.3, function() self.button.SpellHighlightAnim:Play() end)
+end
+
+function o:DisableFlashAnimation()
+  if not self.button.SpellHighlightAnim:IsPlaying() then return end
+  self.button.SpellHighlightAnim:Stop()
+end

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonWidgetMixin.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonWidgetMixin.lua
@@ -155,7 +155,7 @@ function o:SetActionFromCursor(cursor)
     end)
   end
 
-  self.button:UpdateState('ApplyCursorAction')
+  self.button:UpdateState('SetActionFromCursor')
   self.button:UpdateFlash()
   self.button:UpdateAnimation()
   self.button:UpdateUsable()
@@ -238,6 +238,10 @@ function o:GetActionInfo()
   return nil, nil
 end
 
+--- #### NOTES:
+--- - Druid prowl is a normal spell
+--- - Shaman Ghost Wolf form is not a real form, but it does honor GetShapeshiftForm() when active.
+--- - Rogue stealth, warrior stance, pally blessings, etc.. are treated as forms in MoPs+
 --- @return TextureIcon?
 function o:GetActionTexture()
   local btn = self.button
@@ -248,11 +252,13 @@ function o:GetActionTexture()
   local iconID, shouldDim = nil, false
   if au.IsSpell(typeVal) then
     local isShapeshiftSpell, active, activeIcon = unit:IsShapeShiftSpell(id)
-    if not (isShapeshiftSpell and active) then
+    if druid:IsProwl(id) and unit:IsStealthActive() then
+      iconID = unit:GetStealthedIcon()
+    elseif isShapeshiftSpell and active then
+      iconID, shouldDim = self:GetShapeshiftSpellActionTexture(id, active, activeIcon)
+    else
       local info = comp:GetSpellInfo(id)
       if info then iconID = info.iconID end
-    else
-      iconID, shouldDim = self:GetShapeshiftSpellActionTexture(active, activeIcon)
     end
   elseif au.IsItem(typeVal) then
     au.IfItem(self:GetAttributeItemID(), function(itemInfo)
@@ -267,20 +273,26 @@ function o:GetActionTexture()
   return iconID
 end
 
+--- @param spellID SpellID
 --- @param shapeshiftSpellActive boolean
 --- @param activeIcon Icon
 --- @return Icon, boolean @Icon and whether it should be dimmed
-function o:GetShapeshiftSpellActionTexture(shapeshiftSpellActive, activeIcon)
+function o:GetShapeshiftSpellActionTexture(spellID, shapeshiftSpellActive, activeIcon)
   local formOrStealthActive = isShapeshiftSpell == true
   local iconID, shouldDim = activeIcon, false
 
   if unit:IsStealthActive()
-      and (druid:IsProwl(id) or rogue:IsStealth(id)) then
+      and (druid:IsProwl(spellID) or rogue:IsStealth(spellID)) then
     -- Druid and Rogue use the same stealth icon
-    shouldDim = true
-    iconID = unit:GetStealthedIcon()
-  elseif shapeshiftSpellActive and unit:IsPriest() then
-    iconID = priest:GetActiveShapeshiftFormIcon()
+    shouldDim, iconID = true, unit:GetStealthedIcon()
+  elseif shapeshiftSpellActive then
+    if unit:IsPriest() then
+      iconID = priest:GetActiveShapeshiftFormIcon()
+    else
+      -- in MoP, rogue stealth is a shapeshift form
+      -- druid and rogues have the same shapeshift form active icon
+      iconID = unit:GetActiveShapeshiftFormIcon()
+    end
   end
 
   return iconID, shouldDim
@@ -350,21 +362,33 @@ function o:GetDebugName()
       :format(self.button:GetName(), self.index, self.barIndex)
 end
 
---- If a SpellInfoData table is provided, it is assumed to be the
---- return value of Compat:GetSpellInfo().
---- @see Compat#GetSpellInfo(spellIDOrName) : SpellInfoData
 --- @param spellID SpellID
 function o:SetActionSpell(spellID)
-
+  if LE_EXPANSION_LEVEL_CURRENT >= LE_EXPANSION_MISTS_OF_PANDARIA then
+    return self:SetActionSpellByName(spellID)
+  end
   self:SetAttribute(attr.type, atyp.spell)
   local isShapeShiftSpell = unit:IsShapeShiftSpell(spellID)
-  if isShapeShiftSpell or (cns:IsMists() and au.IsTalentSpell(spellID)) then
+  if isShapeShiftSpell or au.IsTalentSpell(spellID) then
     au.IfSpell(spellID, function(spell)
       self:SetAttribute(atyp.spell, spell.name)
     end)
   else
     self:SetAttribute(atyp.spell, spellID)
   end
+end
+
+--- MoP-specific spell attribute setter. In MoP, spells have no ranks, so spell names are
+  --- unambiguous and can always be used safely. Some spells (e.g. Mind Flay, spellID 15407)
+  --- fail to fire when set by ID because the deprecated IsSpellKnown() returns false for them,
+  --- which is what the secure button system uses internally to resolve spells. Setting by name
+  --- bypasses this and works reliably for all MoP spells.
+--- @param spellID SpellID
+function o:SetActionSpellByName(spellID)
+  au.IfSpell(spellID, function(spell)
+    self:SetAttribute(attr.type, atyp.spell)
+    self:SetAttribute(atyp.spell, spell.name)
+  end)
 end
 
 --- @param itemID ItemID

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonWidgetMixin.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonWidgetMixin.lua
@@ -11,6 +11,7 @@ local attr, atyp = cns:constants()
 local Str_IsBlank = cns:String().IsBlank
 
 local C_IsSpellKnown = C_SpellBook.IsSpellKnown
+local C_GetItemCount = C_Item.GetItemCount
 
 --[[-----------------------------------------------------------------------------
 Module::ButtonWidgetMixin
@@ -58,6 +59,26 @@ function o:UpdateAction(name, val)
   if Str_IsBlank(val) then self.button.icon:SetTexture(nil); return end
   self.button:Update()
 end
+
+function o:UpdateCount()
+  local btn = self.button
+  local countText = btn.Count
+  if not countText then return end
+
+  local typeVal, id = self:GetActionInfo()
+  if not id then countText:SetText(''); return end
+
+  if au.IsItem(typeVal) then
+    au.IfItem(id, function(itemInfo)
+      -- includeBank=false, includeUses=true (captures charges), includeReagentBank=false
+      local count = C_GetItemCount(id, false, true, false) or 0
+      countText:SetText(count > 1 and count or '')
+    end)
+  else
+    countText:SetText('')
+  end
+end
+
 
 --- @return boolean
 function o:IsEmpty() return Str_IsBlank(self:GetAttribute(attr.type)) end
@@ -171,13 +192,12 @@ function o:__ResetVisuals()
   btn:SetChecked(false)
   btn:SetButtonStateNormal()
   
-  -- Stop flashing if you use it
-  if btn.ClearFlash then btn:ClearFlash() end
-
   btn.widget:DisableFlashAnimation()
 
   -- Remove any desaturation
   if btn.icon then btn.icon:SetDesaturated(false) end
+
+  btn.Count:SetText('')
 end
 
 --- @private

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonWidgetMixin.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/ButtonWidgetMixin.lua
@@ -68,17 +68,21 @@ function o:UpdateCount()
   local typeVal, id = self:GetActionInfo()
   if not id then countText:SetText(''); return end
 
+  local count = ''
   if au.IsItem(typeVal) then
     au.IfItem(id, function(itemInfo)
       -- includeBank=false, includeUses=true (captures charges), includeReagentBank=false
-      local count = C_GetItemCount(id, false, true, false) or 0
-      countText:SetText(count > 1 and count or '')
+      local n = C_GetItemCount(id, false, true, false) or 0
+      if n > 1 then count = n end
     end)
-  else
-    countText:SetText('')
+  elseif au.IsSpell(typeVal) then
+    au.IfSpellCharges(id, function(spId, spc)
+      local current, max = spc.currentCharges, spc.maxCharges
+      if current and max and max > 1 and current > 0 then count = current end
+    end)
   end
+  countText:SetText(count)
 end
-
 
 --- @return boolean
 function o:IsEmpty() return Str_IsBlank(self:GetAttribute(attr.type)) end
@@ -117,8 +121,6 @@ function o:ApplyButtonConfig()
   local bc = btn:GetButtonConfig()
   if not (bc and bc.type and bc.id) then self:ResetButton(); return end
 
-  self:SetAttribute(attr.type, bc.type)
-
   if au.IsSpell(bc.type) then
     -- if the spell is no longer known (may be true for lower-rank non-mana spells)
     local known, nextKnownSp = au.IsSpellKnown(bc.id)
@@ -126,15 +128,7 @@ function o:ApplyButtonConfig()
       if nextKnownSp then bc.id = nextKnownSp.spellID
       else bc.id = nil end
     end
-    if bc.id then
-      local isShapeShiftSpell, active = unit:IsShapeShiftSpell(bc.id)
-      if isShapeShiftSpell then
-        local sp = comp:GetSpellName(bc.id)
-        self:SetAttribute(bc.type, sp)
-      else
-        self:SetAttribute(bc.type, bc.id)
-      end
-    end
+    if bc.id then self:SetActionSpell(bc.id) end
   elseif au.IsItem(bc.type) then
      self:SetActionItem(bc.id)
   end
@@ -152,7 +146,7 @@ function o:SetActionFromCursor(cursor)
   if cursor:IsSpell() then
     au.IfSpell(cursor:GetSpellID(), function(spell)
       self:SetActionSpell(spell.spellID)
-      btnC.id =  spell.spellID
+      btnC.id = spell.spellID
     end)
   elseif cursor:IsItem() then
     au.IfItem(cursor:GetItemID(), function(itemInfo)
@@ -251,39 +245,45 @@ function o:GetActionTexture()
   if not id then return nil end
   if au.IsMount(typeVal) then return end
 
-  local iconID
+  local iconID, shouldDim = nil, false
   if au.IsSpell(typeVal) then
-    if unit:CanShapeShift() then
-      local formOrStealthActive = false
-      -- some shapeshifts have
-      -- different icons when active
-      if unit:IsStealthActive()
-          and (druid:IsProwl(id) or rogue:IsStealth(id)) then
-        -- Druid and Rogue use the same stealth icon
-        formOrStealthActive = true
-        iconID = unit:GetStealthedIcon()
-      elseif priest:IsShadowFormSpell(id) and priest:IsShapeShifted() then
-        formOrStealthActive = true
-        iconID = priest:GetShadowFormActiveIcon()
-      elseif shammy:IsGhostWolfSpell(id) and shammy:IsInGhostWolfForm() then
-        iconID = shammy:GetFormActiveIcon()
-      end
-      if formOrStealthActive then
-        btn:DimIcon()
-      else
-        btn:SetIconNormalVertex()
-      end
-    end
-    if not iconID then
+    local isShapeshiftSpell, active, activeIcon = unit:IsShapeShiftSpell(id)
+    if not (isShapeshiftSpell and active) then
       local info = comp:GetSpellInfo(id)
-      if info and info.iconID then iconID = info.iconID end
+      if info then iconID = info.iconID end
+    else
+      iconID, shouldDim = self:GetShapeshiftSpellActionTexture(active, activeIcon)
     end
   elseif au.IsItem(typeVal) then
     au.IfItem(self:GetAttributeItemID(), function(itemInfo)
-        iconID = itemInfo.icon
+      iconID = itemInfo.icon
     end)
   end
+
+  if shouldDim then btn:DimIcon()
+  else btn:SetIconNormalVertex()
+  end
+
   return iconID
+end
+
+--- @param shapeshiftSpellActive boolean
+--- @param activeIcon Icon
+--- @return Icon, boolean @Icon and whether it should be dimmed
+function o:GetShapeshiftSpellActionTexture(shapeshiftSpellActive, activeIcon)
+  local formOrStealthActive = isShapeshiftSpell == true
+  local iconID, shouldDim = activeIcon, false
+
+  if unit:IsStealthActive()
+      and (druid:IsProwl(id) or rogue:IsStealth(id)) then
+    -- Druid and Rogue use the same stealth icon
+    shouldDim = true
+    iconID = unit:GetStealthedIcon()
+  elseif shapeshiftSpellActive and unit:IsPriest() then
+    iconID = priest:GetActiveShapeshiftFormIcon()
+  end
+
+  return iconID, shouldDim
 end
 
 --- @param callbackFn fun(icon:Icon):void
@@ -306,8 +306,8 @@ function o:GetAttributeType() return self.button:GetAttribute(attr.type) end
 --- This is called from PreClick() and drag handlers before manipulating the
 --- cursor or replacing the button's action.
 function o:SuspendAction()
-  local t = self:GetAttributeType()
-  if not t then return end
+  local at = self:GetAttributeType()
+  if not at then return end
   cns:SetGlobalAttribute(attr.suspended_type, self:GetAttributeType())
   self:ClearAttributeType()
 end
@@ -340,8 +340,8 @@ end
 
 function o:GetAttributeSpell() return self:GetAttribute(atyp.spell) end
 
-function o:MatchesActiveButtonSpellID(spellID)
-  local _, id = self.button:GetActionInfo()
+function o:MatchesSpellID(spellID)
+  local _, id = self:GetActionInfo()
   return spellID == id or spellID == self.itemSpellID
 end
 
@@ -355,8 +355,16 @@ end
 --- @see Compat#GetSpellInfo(spellIDOrName) : SpellInfoData
 --- @param spellID SpellID
 function o:SetActionSpell(spellID)
+
   self:SetAttribute(attr.type, atyp.spell)
-  self:SetAttribute(atyp.spell, spellID)
+  local isShapeShiftSpell = unit:IsShapeShiftSpell(spellID)
+  if isShapeShiftSpell or (cns:IsMists() and au.IsTalentSpell(spellID)) then
+    au.IfSpell(spellID, function(spell)
+      self:SetAttribute(atyp.spell, spell.name)
+    end)
+  else
+    self:SetAttribute(atyp.spell, spellID)
+  end
 end
 
 --- @param itemID ItemID
@@ -412,6 +420,24 @@ function o:RequiresAttackAnimation()
   local typeVal, id = self:GetActionInfo()
   if not (typeVal and id) then return false end
   return au.IsSpell(typeVal) and au.IsAutoAttackInProgress(id)
+end
+
+function o:ShowOverlayGlow()
+  local btn = self.button
+  if ActionButtonSpellAlertManager then
+    ActionButtonSpellAlertManager:ShowAlert(btn)
+  elseif ActionButton_ShowOverlayGlow then
+    ActionButton_ShowOverlayGlow(btn)
+  end
+end
+
+function o:HideOverlayGlow()
+  local btn = self.button
+  if ActionButtonSpellAlertManager then
+    ActionButtonSpellAlertManager:HideAlert(btn)
+  elseif ActionButton_HideOverlayGlow then
+    ActionButton_HideOverlayGlow(btn)
+  end
 end
 
 function o:EnableFlashAnimation()

--- a/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/WorldEventsFrameMixin.lua
+++ b/ActionbarPlus-BarsUI/Modules/Button_2_0_3_Components/WorldEventsFrameMixin.lua
@@ -32,7 +32,7 @@ Mental model:
 > The world changed. All buttons re-evaluate.
 ---------------------------------------------------------------------]]
 
---- @type Namespace_ABP_2_0
+--- @type Namespace_ABP_BarsUI_2_0
 local ns = select(2, ...)
 local p, t = ns:log('WorldEventsFrame')
 

--- a/ActionbarPlus-BarsUI/Modules/Namespace/Namespace.lua
+++ b/ActionbarPlus-BarsUI/Modules/Namespace/Namespace.lua
@@ -1,8 +1,7 @@
 --[[-------------------------------------------------------------------
 Namespace_ABP_BarsUI
 ---------------------------------------------------------------------]]
---- @type string
-local addon
+local addon, xns = ...
 
 --- @class Namespace_ABP_BarsUI_2_0
 --- @field name Name The addon name
@@ -13,9 +12,9 @@ local addon
 --- @field buttonTemplate Name The button template name to use for action buttons (see BarFrame.xml and BarModuleFactory.lua)
 --- @field M BarsUI_Modules_ABP_2_0 The module names
 --- @field O BarsUI_Modules_ABP_2_0 The module objects
-local ns
+local ns = xns
 
-addon, ns = ...; ns.name = addon; ns.nameShort = 'ABP2|cff8EB9FFBarsUI|r'
+ns.name = addon; ns.nameShort = 'ABP2|cff8EB9FFBarsUI|r'
 ABP_BARSUI_NS = ns
 
 --- @type BarsUI_Modules_ABP_2_0
@@ -78,4 +77,3 @@ function ns:log(moduleName)
   local h = self.logHolder
   return h.printer(moduleName), h.tracer(moduleName)
 end
-

--- a/ActionbarPlus-Core/ActionbarPlus-Core-Mists.toc
+++ b/ActionbarPlus-Core/ActionbarPlus-Core-Mists.toc
@@ -1,4 +1,4 @@
-## Interface: 20505
+## Interface: 50503
 ## Version: @project-version@
 ## Title: |TInterface/AddOns/ActionbarPlus-Core/Assets/Textures/logo-v2-64x:18:18|tActionbar|cff1784d1Plus|r|cffffffff-Core|r
 

--- a/ActionbarPlus-Core/Libs/Developer/Developer.lua
+++ b/ActionbarPlus-Core/Libs/Developer/Developer.lua
@@ -4,6 +4,7 @@ local trace_cvar = ns.trace_ui_cvar
 local Str_IsBlank = ns:String().IsBlank
 local p, t = ns:log('Developer')
 local unit = ns.O.UnitUtil
+local comp = ns.O.Compat
 
 --- @class Developer_ABP_2_0 : AceEvent_3_0
 local o = ns:NewAceEvent(); Developer_ABP_2_0 = o; dd = o
@@ -48,8 +49,19 @@ function o:devMsg(msg)
 end
 
 --- @param itemInfo ItemName|ItemID|ItemLink
---- @return ItemCooldownData?
+--- @return ItemCooldownInfo?
 function o:GetItemCooldown(itemInfo)
-  return ns.O.Compat:GetItemCooldown(itemInfo)
+  return comp:GetItemCooldown(itemInfo)
 end
 
+function o:IsSealActive(spellID)
+  if not (spellID and C_UnitAuras and C_UnitAuras.GetBuffDataByIndex) then return false end
+  local index = 1
+  while true do
+    local aura = C_UnitAuras.GetBuffDataByIndex('player', index)
+    if not aura then break end
+    if aura.spellId == spellID then return true end
+    index = index + 1
+  end
+  return false
+end

--- a/ActionbarPlus-Core/Libs/Modules/API/ActionUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/ActionUtil.lua
@@ -169,6 +169,7 @@ function o.IsCompanion(typeVal) return typeVal == atyp.companion end
 --- @param spellID SpellID
 --- @return boolean
 function o.IsTalentSpell(spellID)
+  if LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_MISTS_OF_PANDARIA then return false end
   if not (spellID and C_GetTalentInfo) then return false end
   for tier = 1, MOP_TALENT_TIERS do
     for column = 1, MOP_TALENT_COLUMNS do

--- a/ActionbarPlus-Core/Libs/Modules/API/ActionUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/ActionUtil.lua
@@ -15,7 +15,9 @@ local C_IsSpellUsable     = C_Spell.IsSpellUsable
 local C_IsUsableItem      = C_Item.IsUsableItem
 
 local unit, shaman, priest = O.UnitUtil, O.ShamanUtil, O.PriestUtil
+
 local ATTACK_SPELL_ID = 6603
+local SHOOT_SPELL_ID  = 5019
 
 --[[-----------------------------------------------------------------------------
 Module::ActionUtil
@@ -95,12 +97,18 @@ function o.IsUsableAction(typeVal, id)
   return false, false
 end
 
---- Spells:
---- Attack (6603)
 --- @return boolean
-function o.SpellRequiresAttackAnim(spellID)
-  return spellID == ATTACK_SPELL_ID
-end
+function o.IsAutoAttackInProgress(spellID) return o.IsAutoAttackSpell(spellID) and o.IsCurrentSpell(spellID) end
+--- @return boolean
+function o.IsShootingInProgress(spellID) return o.IsShootSpell(spellID) and o.IsCurrentSpell(spellID) end
+
+--- @return boolean
+function o.IsAutoAttackSpell(spellID) return spellID == ATTACK_SPELL_ID end
+--- @return boolean
+function o.IsShootSpell(spellID) return spellID == SHOOT_SPELL_ID end
+--- @param spellID SpellID
+--- @return boolean
+function o.IsCurrentSpell(spellID) return C_IsCurrentSpell(spellID) or C_IsAutoRepeatSpell(spellID) end
 
 --- @param typeVal string The button attribute 'type' value
 --- @param id Identifier The context id; 'spell', 'item', etc...
@@ -113,12 +121,6 @@ function o.IsCurrentAction(typeVal, id)
       return C_Item.IsCurrentItem(id)
   end
   return false
-end
-
---- @param spellID SpellID
---- @return boolean
-function o.IsCurrentSpell(spellID)
-  return C_IsCurrentSpell(spellID) or C_IsAutoRepeatSpell(spellID)
 end
 
 --- @param action Name The action name; i.e. 'spell', 'item', etc..

--- a/ActionbarPlus-Core/Libs/Modules/API/ActionUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/ActionUtil.lua
@@ -13,11 +13,14 @@ local C_GetSpellPowerCost = C_Spell.GetSpellPowerCost
 local C_IsSpellKnown      = C_SpellBook.IsSpellKnown
 local C_IsSpellUsable     = C_Spell.IsSpellUsable
 local C_IsUsableItem      = C_Item.IsUsableItem
+local C_GetTalentInfo     = C_SpecializationInfo and C_SpecializationInfo.GetTalentInfo
 
 local unit, shaman, priest = O.UnitUtil, O.ShamanUtil, O.PriestUtil
 
-local ATTACK_SPELL_ID = 6603
-local SHOOT_SPELL_ID  = 5019
+local ATTACK_SPELL_ID     = 6603
+local SHOOT_SPELL_ID      = 5019
+local MOP_TALENT_TIERS    = 6
+local MOP_TALENT_COLUMNS  = 3
 
 --[[-----------------------------------------------------------------------------
 Module::ActionUtil
@@ -162,11 +165,34 @@ function o.IsBattlePet(typeVal) return typeVal == atyp.battlepet end
 --- @return boolean
 function o.IsCompanion(typeVal) return typeVal == atyp.companion end
 
+--- MoP only: 6 tiers x 3 columns (left=1, middle=2, right=3)
+--- @param spellID SpellID
+--- @return boolean
+function o.IsTalentSpell(spellID)
+  if not (spellID and C_GetTalentInfo) then return false end
+  for tier = 1, MOP_TALENT_TIERS do
+    for column = 1, MOP_TALENT_COLUMNS do
+      local info = C_GetTalentInfo({ tier = tier, column = column })
+      if info and info.selected and info.spellID == spellID then return true end
+    end
+  end
+  return false
+end
+
 --- @param spell SpellIdentifier
 --- @param callbackFn fun(spell: SpellInfo)
 function o.IfSpell(spell, callbackFn)
   local spellInfo = comp:GetSpellInfo(spell)
   if spellInfo then callbackFn(spellInfo) end
+end
+
+--- @param spell SpellIdentifier
+--- @param callbackFn fun(spellID:SpellID, charge: SpellChargeInfo)
+function o.IfSpellCharges(spell, callbackFn)
+  o.IfSpell(spell, function(sp)
+    local charge = comp:GetSpellCharges(sp.spellID)
+    if charge then callbackFn(sp.spellID, charge) end
+  end)
 end
 
 --- Execute callback if a cooldown exists
@@ -216,3 +242,14 @@ end
 --- @return boolean
 function o.SpellDoesNotRequireMana(spell) return not o.SpellRequiresMana(spell) end
 
+--- @param spellID SpellID
+--- @return boolean
+function o.IsActiveShapeshiftForm(spellID)
+  if shaman:IsShaman() then
+    return shaman:IsInGhostWolfForm() and shaman:IsGhostWolfSpell(spellID)
+  end
+  local index = unit:GetShapeshiftForm()
+  if not index or index <= 0 then return false end
+  local _, active, _, formSpellID = GetShapeshiftFormInfo(index)
+  return active and formSpellID == spellID
+end

--- a/ActionbarPlus-Core/Libs/Modules/API/Compat.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/Compat.lua
@@ -129,8 +129,17 @@ end
 --- @return SpellCooldownInfo
 function o:GetSpellCooldown(spell)
   assert(Str_IsAnyOf(type(spell), 'number', 'string'),
-    'GetSpellCooldown(spell):: spell should be a string (Spell Name) or number (Spell ID).')
+    'GetSpellCooldown(spell):: spell should be a string (spell name) or number (spell ID).')
   return C_GetSpellCooldown(spell)
+end
+
+--- @see C_Spell.GetSpellCharges()
+--- @param spell SpellIdentifier
+--- @return SpellChargeInfo chargeInfo
+function o:GetSpellCharges(spell)
+  assert(Str_IsAnyOf(type(spell), 'number', 'string'),
+    'GetSpellCharges(spell):: spell should be a string (spell name) or number (spell ID).')
+  return C_Spell.GetSpellCharges(spell)
 end
 
 --- @return UnitCastingData

--- a/ActionbarPlus-Core/Libs/Modules/API/Compat.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/Compat.lua
@@ -70,7 +70,7 @@ end
 --- @return SpellInfo?
 function o:GetSpellInfo(spell)
   local pt = type(spell)
-  assert(pt == 'string' or pt == 'number', 'GetSpellInfo::SpellID should be a number or a string.')
+  assert(Str_IsAnyOf(type(spell), 'string', 'number'), 'GetSpellInfo::SpellID should be a number or a string.')
   return C_GetSpellInfo(spell)
 end
 

--- a/ActionbarPlus-Core/Libs/Modules/API/DruidUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/DruidUtil.lua
@@ -177,11 +177,3 @@ function o:GetCatFormName()
 end
 
 function o:GetFormActiveIcon() return o.DRUID_FORM_ACTIVE_ICON end
-
---- @param spellInfo Profile_Spell
---- @return Icon The shapeshift icon
-function o:GetShapeshiftIcon(spellInfo)
-  if not spellInfo then return nil end
-  if self:IsShapeShiftActive(spellInfo) then return self:GetFormActiveIcon() end
-  return spellInfo.icon
-end

--- a/ActionbarPlus-Core/Libs/Modules/API/PriestUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/PriestUtil.lua
@@ -42,10 +42,21 @@ function o:IsInShadowForm()
           or self:IsBuffActive(self.SHADOW_FORM_SPELL_ID_RETAIL)
 end
 
-function o:GetShadowFormActiveIcon()
+--- @deprecated
+--- @see GetActiveShapeshiftFormIcon()
+function o:GetShadowFormActiveIcon() return self:GetActiveShapeshiftFormIcon() end
+
+function o:GetActiveShapeshiftFormIcon()
   if ns:IsRetail() then return formActiveIcon.retail
   elseif ns:IsMists() then return formActiveIcon.mop end
   return formActiveIcon.default
 end
 
-
+--- @protected
+--- @see UnitUtil_ABP_2_0.GetShapeShiftSpellInfo
+--- @param spellID SpellID
+--- @return boolean? @If {spellID} is a shapeshift spellID
+--- @return boolean? @If {spellID} is active
+function o:GetShapeShiftSpellInfo(spellID)
+  return self:IsShadowFormSpell(spellID), self:IsShapeShifted()
+end

--- a/ActionbarPlus-Core/Libs/Modules/API/RogueUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/RogueUtil.lua
@@ -28,3 +28,5 @@ end
 --- @param spellID SpellID
 --- @return Boolean
 function o:IsStealth(spellID) return spellID == self.STEALTH_SPELL_ID end
+
+function o:GetActiveShapeshiftFormIcon() return o.STEALTHED_ICON end

--- a/ActionbarPlus-Core/Libs/Modules/API/ShamanUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/ShamanUtil.lua
@@ -24,10 +24,21 @@ o.GHOST_WOLF_FORM_ACTIVE_ICON = 136116
 ---@param spellID SpellID
 function o:IsGhostWolfSpell(spellID) return spellID == o.GHOST_WOLF_SPELL_ID end
 
+--- The Ghost Wolf form is not part of GetShapeshiftFormInfo(index),
+--- but does return the index of 1 on GetShapeshiftForm() when shifted
 --- @return boolean @true if in Ghost Wolf form, false otherwise.
 function o:IsInGhostWolfForm()
   return self:IsShaman() and GetShapeshiftForm() == 1
 end
 
---- @return Icon @The icon if form is active
-function o:GetFormActiveIcon() return o.GHOST_WOLF_FORM_ACTIVE_ICON end
+---- @return Icon @The icon if form is active
+--function o:GetActiveShapeshiftFormIcon() return o.GHOST_WOLF_FORM_ACTIVE_ICON end
+
+--- @protected
+--- @see UnitUtil_ABP_2_0.GetShapeShiftSpellInfo
+--- @param spellID SpellID
+--- @return boolean? @If {spellID} is a shapeshift spellID
+--- @return boolean? @If {spellID} is active
+function o:GetShapeShiftSpellInfo(spellID)
+  return self:IsGhostWolfSpell(spellID), self:IsInGhostWolfForm()
+end

--- a/ActionbarPlus-Core/Libs/Modules/API/ShamanUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/ShamanUtil.lua
@@ -25,14 +25,11 @@ o.GHOST_WOLF_FORM_ACTIVE_ICON = 136116
 function o:IsGhostWolfSpell(spellID) return spellID == o.GHOST_WOLF_SPELL_ID end
 
 --- The Ghost Wolf form is not part of GetShapeshiftFormInfo(index),
---- but does return the index of 1 on GetShapeshiftForm() when shifted
+--- Ghost Wolf form is not a real form, but it does honor GetShapeshiftForm() when active.
 --- @return boolean @true if in Ghost Wolf form, false otherwise.
 function o:IsInGhostWolfForm()
   return self:IsShaman() and GetShapeshiftForm() == 1
 end
-
----- @return Icon @The icon if form is active
---function o:GetActiveShapeshiftFormIcon() return o.GHOST_WOLF_FORM_ACTIVE_ICON end
 
 --- @protected
 --- @see UnitUtil_ABP_2_0.GetShapeShiftSpellInfo

--- a/ActionbarPlus-Core/Libs/Modules/API/UnitUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/UnitUtil.lua
@@ -27,16 +27,13 @@ local O, M = ns.O, ns.M
 local comp, UnitClasses = O.Compat, O.Constants.UnitClasses
 local Str_IsAnyOf = ns:String().IsAnyOf
 
---- For all stealth
-local STEALTHED_ICON = 136047
-
 --[[-----------------------------------------------------------------------------
 New Instance
 -------------------------------------------------------------------------------]]
 --- @see Core_Modules_ABP_2_0
 --- @type string
 local libName = M.UnitUtil()
---- @class UnitUtil_ABP_2_0 : BaseLibraryObject
+--- @class UnitUtil_ABP_2_0
 --- @field protected CLASS_ID UnitClass This is an interface field and must be defined by the specific unit
 local S = {}; ns:Register(libName, S)
 S.__index = S
@@ -46,6 +43,27 @@ local p, t = ns:log(libName)
 --[[-------------------------------------------------------------------
 Support Functions
 ---------------------------------------------------------------------]]
+--- @type table<UnitClass, UnitUtil_ABP_2_0>
+local SPECIAL_SHAPESHIFT_SPELL_UNITS
+local SPECIAL_SHAPESHIFT_ICON_UNITS
+
+--- @param playerClass UnitClass
+--- @return UnitUtil_ABP_2_0
+local function GetSpecialShapeshiftUnit(playerClass)
+  if not SPECIAL_SHAPESHIFT_SPELL_UNITS then
+    SPECIAL_SHAPESHIFT_SPELL_UNITS = { ['PRIEST'] = O.PriestUtil, ['SHAMAN'] = O.ShamanUtil }
+  end
+  return SPECIAL_SHAPESHIFT_SPELL_UNITS[playerClass]
+end
+
+local function GetShapeshiftFormIcon(playerClass)
+  if not SPECIAL_SHAPESHIFT_ICON_UNITS then
+    SPECIAL_SHAPESHIFT_ICON_UNITS = { ['PRIEST'] = O.PriestUtil, ['ROGUE'] = O.RogueUtil }
+  end
+  local u = SPECIAL_SHAPESHIFT_ICON_UNITS[playerClass]
+  return u and u:GetActiveShapeshiftFormIcon()
+end
+
 --- @return SpecInfo_ABP_2_0
 local function NewSpecInfo()
   return {
@@ -59,7 +77,7 @@ end
 --- @return boolean True if `toMatch` is found in the varargs, false otherwise.
 local function IsAnyOfBuff(toMatch, ...)
   for i = 1, select('#', ...) do
-    --- @type SpellInfoShort
+    --- @type SpellInfo
     local val = select(i, ...)
     local spellID = val and val.id
     if toMatch == spellID then return true end
@@ -76,7 +94,9 @@ local o = S
 o.C = { UnitClasses = UnitClasses }
 
 o.ADDON_TEXTURES_DIR_FORMAT = 'interface/addons/actionbarplus/Core/Assets/Textures/%s'
-o.stealthedIcon = o.ADDON_TEXTURES_DIR_FORMAT:format('spell_nature_invisibilty_active')
+o.ACTIVE_SHAPE_SHIFT_ICON = 136116
+--- Default Stealthed Icon
+o.STEALTHED_ICON = 136047
 
 --- @overload fun(unitClass:UnitClass) : UnitUtil_ABP_2_0
 --- @param unitClass UnitClass
@@ -102,18 +122,18 @@ function o:ClassID() return self.CLASS_ID end
 ---Example:
 --- @param optionalUnit string
 --- @see Blizzard_UnitId
---- @return UnitClass, UnitClassID One of DRUID, ROGUE, PRIEST, etc... returned with the ID
+--- @return UnitClass, UnitClassID @One of DRUID, ROGUE, PRIEST, etc... returned with the ID
 function o:GetUnitClass(optionalUnit) return UnitClassBase(optionalUnit or 'player') end
+
+--- @see GetUnitClass
+--- @return UnitClass, UnitClassID
+function o:GetPlayerUnitClass() return self:GetUnitClass() end
 
 --- @return UnitClassType
 function o:GetUnitClassX(optionalUnit)
   local name = self:GetUnitClass(optionalUnit)
   return UnitClasses[name]
 end
-
---- @see UnitClasses
---- @return string, number One of DRUID, ROGUE, PRIEST, etc...
-function o:GetPlayerUnitClass() return self:GetUnitClass() end
 
 --- /dump select(2, UnitClass('player'))
 ---Example:
@@ -157,6 +177,8 @@ function o:IsUs(unitClass)
   return self.CLASS_ID == pClass
 end
 
+--- @param unit UnitID
+function o:UnitIsPlayer(unit) return unit == 'player' end
 function o:IsDruid() return self:IsUs(UnitClasses.DRUID()) end
 function o:IsPriest() return self:IsUs(UnitClasses.PRIEST()) end
 function o:IsPaladin() return self:IsUs(UnitClasses.PALADIN()) end
@@ -168,6 +190,7 @@ function o:IsStealthActive() return IsStealthed and IsStealthed() end
 --- @return Boolean
 function o:CanShapeShift()
   if self:IsShaman() or self:IsPriest() then return true end
+  if ns:IsMists() and self:IsPaladin() then return true end
   return GetNumShapeshiftForms and GetNumShapeshiftForms() > 0
 end
 
@@ -177,28 +200,36 @@ function o:IsShapeShifted() return self:GetShapeshiftForm() > 0 end
 --- @param spellID SpellID
 --- @return boolean? @If {spellID} is a shapeshift spellID
 --- @return boolean? @If {spellID} is active
+--- @return Icon? @The form active icon
 function o:IsShapeShiftSpell(spellID)
-  local isShapeShiftSpell, active
-  local shaman, priest = O.ShamanUtil, O.PriestUtil
-  if self:IsShaman() then
-    isShapeShiftSpell, active = shaman:IsGhostWolfSpell(spellID), true
-  elseif self:IsPriest() then
-    isShapeShiftSpell, active = priest:IsShadowFormSpell(spellID), priest:IsInShadowForm()
-  else
-    for i = 1, GetNumShapeshiftForms() do
-      local icon, active, castable, spid = GetShapeshiftFormInfo(i)
-      if spid == spellID then return true, active == true end
-    end
-    return false, false
-  end
-
-  return isShapeShiftSpell, active
+  local playerClass = self:GetPlayerUnitClass()
+  local specialUnit = GetSpecialShapeshiftUnit(playerClass)
+  if specialUnit then return specialUnit:GetShapeShiftSpellInfo(spellID) end
+  return self:GetShapeShiftSpellInfo(spellID)
 end
+
+--- Meant to be overridden by units to
+--- reflect their current shapeshift state
+--- @protected
+--- @param spellID SpellID
+--- @return boolean? @If {spellID} is a shapeshift spellID
+--- @return boolean? @If {spellID} is active
+--- @return Icon? @The form active icon
+function o:GetShapeShiftSpellInfo(spellID)
+  local index = self:GetShapeshiftForm()
+  if not index or index <= 0 then return false, false, nil end
+  local formActiveIcon = GetShapeshiftFormIcon(self:GetPlayerUnitClass())
+    or self:GetActiveShapeshiftFormIcon()
+  local _, active, _, spid = GetShapeshiftFormInfo(index)
+  return spid == spellID, active, formActiveIcon
+end
+
 --- @return Icon
-function o:GetStealthedIcon() return STEALTHED_ICON end
+function o:GetStealthedIcon() return o.STEALTHED_ICON end
 --- @return Index|0 The form index if any; 0 if not shapeshifted
 function o:GetShapeshiftForm() return GetShapeshiftForm and GetShapeshiftForm() end
---shapeshiftIcon, active, castable, spellID
+--- @return Icon
+function o:GetActiveShapeshiftFormIcon() return o.ACTIVE_SHAPE_SHIFT_ICON end
 
 --- @return boolean?
 --- @param callbackFn fun(data:ShapeshiftFormData):void
@@ -248,7 +279,7 @@ function o:UpdateBuffs(filterFn)
       if filterFn(spellID) and self:IsOwnSpell(spellID) then
         local name = comp:GetSpellName(spellID)
         p:t(function() return "Own spell: id=%s name=%s", spellID, tostring(name) end)
-        --- @type SpellInfoShort
+        --- @type SpellInfo
         local spellInfo = { id = spellID, name = name }
         table.insert(ns.playerBuffs, spellInfo)
       end

--- a/ActionbarPlus-Core/Libs/Modules/API/UnitUtil.lua
+++ b/ActionbarPlus-Core/Libs/Modules/API/UnitUtil.lua
@@ -178,7 +178,8 @@ function o:IsUs(unitClass)
 end
 
 --- @param unit UnitID
-function o:UnitIsPlayer(unit) return unit == 'player' end
+--- @return boolean
+function o:IsPlayer(unit) return unit == 'player' end
 function o:IsDruid() return self:IsUs(UnitClasses.DRUID()) end
 function o:IsPriest() return self:IsUs(UnitClasses.PRIEST()) end
 function o:IsPaladin() return self:IsUs(UnitClasses.PALADIN()) end

--- a/ActionbarPlus-Core/Libs/Namespace/Namespace.lua
+++ b/ActionbarPlus-Core/Libs/Namespace/Namespace.lua
@@ -9,9 +9,8 @@ Type:Namespace
 --- @alias TraceFn_ABP_2_0 fun(...: any) : void @Printer function that outputs plain values to Blizzard Trace UI (like print)
 --- @alias TraceFnFormatted_ABP_2_0 fun(...: any) : void @Printer function that outputs formatted values to Blizzard Trace UI (like print)
 --
---
---- @type string
-local addon
+
+local addon, xns = ...
 
 --- @class Namespace_ABP_2_0 : Kapresoft-AceLib-2-0, Kapresoft-GameVersionMixin-2-0
 --- @field private LOG_NAME Name
@@ -29,9 +28,9 @@ local addon
 --- @field tr TraceFn_ABP_2_0
 --- @field M Core_Modules_ABP_2_0   @The module names
 --- @field O Core_Modules_ABP_2_0   @The module objects
-local ns
+local ns = xns
 
-addon, ns = ...; ns.name = addon; ns.nameShort='ABP2'
+ns.name = addon; ns.nameShort='ABP2'
 Mixin(ns, GVM, AceLib); ABP_CORE_NS = ns
 
 --[[-------------------------------------------------------------------

--- a/ActionbarPlus-Core/Libs/_Libs.xml
+++ b/ActionbarPlus-Core/Libs/_Libs.xml
@@ -8,13 +8,13 @@
     <Script file='Developer\DeveloperSetup.lua'/>
     <!--@end-do-not-package@-->
     <Script file="Modules\API\Compat.lua" />
-    <Script file="Modules\API\ActionUtil.lua"/>
     <Script file="Modules\API\SpellUtil.lua" />
     <Script file="Modules\API\UnitUtil.lua"/>
     <Script file="Modules\API\DruidUtil.lua"/>
     <Script file="Modules\API\PriestUtil.lua"/>
     <Script file="Modules\API\RogueUtil.lua"/>
     <Script file="Modules\API\ShamanUtil.lua"/>
+    <Script file="Modules\API\ActionUtil.lua"/>
     <!--
     TODO: Implement
     <Script file="Modules\API\ShamanUnitMixin.lua"/>


### PR DESCRIPTION
MoP spell fixes: set spells by name, shapeshift texture refactor, unit/namespace cleanup

- ButtonWidgetMixin: add SetActionSpellByName() for MoP — avoids IsSpellKnown() returning
  false for some spells (e.g. Mind Flay); MoP has no ranks so name is always unambiguous
- ButtonWidgetMixin: refactor GetActionTexture() condition order for readability; fix
  GetShapeshiftSpellActionTexture() to accept spellID param; expand MoP shapeshift icon
  handling beyond Priest to all classes via GetActiveShapeshiftFormIcon()
- ActionUtil: guard IsTalentSpell() to MoP+ only, short-circuit on earlier expansions
- ActionEventsFrameMixin: replace unitName == "player" checks with unit:IsPlayer()
- UnitUtil: rename UnitIsPlayer() to IsPlayer()
- Compat: use Str_IsAnyOf() in GetSpellInfo() type assertion
- ShamanUtil: clarify Ghost Wolf comment, remove dead commented-out method
- Namespace (Core + BarsUI): simplify vararg unpacking using xns pattern
- WorldEventsFrameMixin: fix namespace type annotation
