### PR TITLE
Simplify TOC categorization: single Category tag + Group hierarchy

### DIFF
--- a/ActionbarPlus-BarsUI/ActionbarPlus-BarsUI.toc
+++ b/ActionbarPlus-BarsUI/ActionbarPlus-BarsUI.toc
@@ -9,19 +9,8 @@
 ## DefaultState: enabled
 ## RequiredDeps: ActionbarPlus-Core
 ## OptionalDeps: ActionbarPlus-Masque
+## Category: ActionbarPlus
 ## Group: ActionbarPlus-Core
-
-## Category-enUS: Action Bars
-## Category-deDE: Aktionsleisten
-## Category-esES: Barras de acción
-## Category-esMX: Barras de acción
-## Category-frFR: Barres d’actions
-## Category-itIT: Barre delle azioni
-## Category-koKR: 행동 단축바
-## Category-ptBR: Barras de ação
-## Category-ruRU: Панели действий
-## Category-zhCN: 动作条
-## Category-zhTW: 動作條
 
 ## X-Credits: Antonio W. Lagnada (kapresoft@gmail.com)
 ## X-Category: Action Bars

--- a/ActionbarPlus-Core/ActionbarPlus-Core.toc
+++ b/ActionbarPlus-Core/ActionbarPlus-Core.toc
@@ -10,18 +10,8 @@
 ## DefaultState: enabled
 ## SavedVariables: ABP_PLUS
 ## OptionalDeps: Ace3, DevSuite
-
-## Category-enUS: Action Bars
-## Category-deDE: Aktionsleisten
-## Category-esES: Barras de acción
-## Category-esMX: Barras de acción
-## Category-frFR: Barres d’actions
-## Category-itIT: Barre delle azioni
-## Category-koKR: 행동 단축바
-## Category-ptBR: Barras de ação
-## Category-ruRU: Панели действий
-## Category-zhCN: 动作条
-## Category-zhTW: 動作條
+## Category: ActionbarPlus
+## Group: ActionbarPlus-Core
 
 ## X-Credits: Antonio W. Lagnada (kapresoft@gmail.com)
 ## X-Category: Action Bars

--- a/ActionbarPlus-OptionsUI/ActionbarPlus-OptionsUI.toc
+++ b/ActionbarPlus-OptionsUI/ActionbarPlus-OptionsUI.toc
@@ -8,19 +8,8 @@
 
 ## DefaultState: enabled
 ## RequiredDeps: ActionbarPlus-Core
+## Category: ActionbarPlus
 ## Group: ActionbarPlus-Core
-
-## Category-enUS: Action Bars
-## Category-deDE: Aktionsleisten
-## Category-esES: Barras de acción
-## Category-esMX: Barras de acción
-## Category-frFR: Barres d'actions
-## Category-itIT: Barre delle azioni
-## Category-koKR: 행동 단축바
-## Category-ptBR: Barras de ação
-## Category-ruRU: Панели действий
-## Category-zhCN: 动作条
-## Category-zhTW: 動作條
 
 ## X-Credits: Antonio W. Lagnada (kapresoft@gmail.com)
 ## X-Category: Action Bars


### PR DESCRIPTION
## Summary
- Replace per-locale `Category-*` lines with a single `## Category: ActionbarPlus` tag on Core/BarsUI/OptionsUI
- Add `## Group: ActionbarPlus-Core` to all three TOCs to reflect Core as the addon-manager group parent

Closes #638.

## Test plan
- [ ] Deploy locally and confirm addon manager (WowUp/CurseForge client) shows correct category and grouping